### PR TITLE
The J-PARC Linac related classes are ready

### DIFF
--- a/py/orbit/lattice/AccLattice.py
+++ b/py/orbit/lattice/AccLattice.py
@@ -148,6 +148,16 @@ class AccLattice(NamedObject, TypedObject):
 				nodes.append(node)
 		return nodes
 		
+	def getNodesOfClass(self,class_of_node):
+		"""
+		Method. Returns nodes off a certain class.
+		"""
+		nodes = []
+		for node in self.__children:
+			if(isinstance(node,class_of_node)):
+				nodes.append(node)
+		return nodes		
+		
 	def getNodesForSubstring(self,sub, no_sub = None):
 		"""
 		Method. Returns nodes with names each of them has the certain substring. 

--- a/py/orbit/parsers/sad_parser.py
+++ b/py/orbit/parsers/sad_parser.py
@@ -471,7 +471,8 @@ class StringFunctions:
 class SAD_Parser:
 	""" SAD parser """
 	_typeChecker = _possibleElementType()
-
+	SADFilePath = ""
+	
 	def __init__(self):
 		""" Create instance of the SAD_Parser class """
 		self.__SAD_Strings =  []
@@ -479,7 +480,6 @@ class SAD_Parser:
 		self.__accElements = []
 		self.__accLines = []
 		self.__unknownLines = []
-		self.__SADFilePath = ""
 		#old style lattice elements and lines
 		self.__lattElems = []
 		self.__lattLines = []
@@ -489,7 +489,7 @@ class SAD_Parser:
 
 	def parse(self,SADfileName):
 		#1-st stage read SAD file into the lines array
-		self.__SADFilePath = os.path.dirname(SADfileName)
+		self.SADFilePath = os.path.dirname(SADfileName)
 		fileName = os.path.basename(SADfileName)
 		#the initilize can be recursive if there are nested SAD files
 		self.__init__()
@@ -650,7 +650,7 @@ class SAD_Parser:
 
 	def initialize(self,SAD_file_name):
 		""" This method will do the preliminary editing the input file."""
-		fl = open(os.path.join(self.__SADFilePath, SAD_file_name))
+		fl = open(os.path.join(self.SADFilePath,SAD_file_name),"r")
 		sad_strings = []
 		str_local = ""
 		for str_in in fl.readlines():

--- a/py/orbit/py_linac/lattice/LinacApertureNodes.py
+++ b/py/orbit/py_linac/lattice/LinacApertureNodes.py
@@ -83,7 +83,7 @@ class LinacPhaseApertureNode(BaseLinacNode):
 	The phase aperture classes removes particles from bunch and places them in the lostbunch
 	if their phases are not inside the min-max phases.
 	"""
-	def __init__(self, frequency = 402.5e+6, name = "aperture"):
+	def __init__(self, frequency = 402.5e+6, name = "phase_aperture"):
 		BaseLinacNode.__init__(self,name)
 		self.aperture = PhaseAperture(frequency)	
 
@@ -122,7 +122,7 @@ class LinacEnergyApertureNode(BaseLinacNode):
 	The phase aperture classes removes particles from bunch and places them in the lostbunch
 	if their phases are not inside the min-max energy.
 	"""
-	def __init__(self, name = "aperture"):
+	def __init__(self, name = "energy_aperture"):
 		BaseLinacNode.__init__(self,name)
 		self.aperture = EnergyAperture()	
 

--- a/py/orbit/py_linac/lattice/LinacApertureNodes.py
+++ b/py/orbit/py_linac/lattice/LinacApertureNodes.py
@@ -10,8 +10,11 @@ import os
 
 from orbit.py_linac.lattice import BaseLinacNode, Quad
 
-# import injection C++ class
+# import aperture C++ classes
 from aperture import Aperture
+from aperture import PhaseAperture
+from aperture import EnergyAperture
+
 
 class LinacApertureNode(BaseLinacNode):
 	"""
@@ -75,6 +78,75 @@ class RectangleLinacApertureNode(LinacApertureNode):
 		LinacApertureNode.__init__(self,3,a,b,pos,c,d,name)
 
 
+class LinacPhaseApertureNode(BaseLinacNode):
+	"""
+	The phase aperture classes removes particles from bunch and places them in the lostbunch
+	if their phases are not inside the min-max phases.
+	"""
+	def __init__(self, frequency = 402.5e+6, name = "aperture"):
+		BaseLinacNode.__init__(self,name)
+		self.aperture = PhaseAperture(frequency)	
 
+	def setMinMaxPhase(self,minPhase,maxPhase):
+		self.aperture.setMinMaxPhase(minPhase,maxPhase)
+		
+	def getMinMaxPhase(self):
+		return self.aperture.getMinMaxPhase()
 
+	def setRfFrequency(self,frequency):
+		self.aperture.setRfFrequency(frequency)
+		
+	def getRfFrequency(self):
+		return self.aperture.getRfFrequency()
+
+	def setPosition(self, pos):
+		BaseLinacNode.setPosition(self,pos)
+		self.aperture.setPosition(self.getPosition())
+
+	def track(self, paramsDict):
+		bunch = paramsDict["bunch"]
+		if(paramsDict.has_key("lostbunch")):
+			lostbunch = paramsDict["lostbunch"]
+			self.aperture.checkBunch(bunch, lostbunch)
+		else:
+			self.aperture.checkBunch(bunch)
+
+	def trackDesign(self, paramsDict):
+		"""
+		This method does nothing for the aperture case.
+		"""
+		pass
+
+class LinacEnergyApertureNode(BaseLinacNode):
+	"""
+	The phase aperture classes removes particles from bunch and places them in the lostbunch
+	if their phases are not inside the min-max energy.
+	"""
+	def __init__(self, name = "aperture"):
+		BaseLinacNode.__init__(self,name)
+		self.aperture = EnergyAperture()	
+
+	def setMinMaxEnergy(self,minEnergy,maxEnergy):
+		self.aperture.setMinMaxEnergy(minEnergy,maxEnergy)
+		
+	def getMinMaxEnergy(self):
+		return self.aperture.getMinMaxEnergy()
+
+	def setPosition(self, pos):
+		BaseLinacNode.setPosition(self,pos)
+		self.aperture.setPosition(self.getPosition())
+
+	def track(self, paramsDict):
+		bunch = paramsDict["bunch"]
+		if(paramsDict.has_key("lostbunch")):
+			lostbunch = paramsDict["lostbunch"]
+			self.aperture.checkBunch(bunch, lostbunch)
+		else:
+			self.aperture.checkBunch(bunch)
+
+	def trackDesign(self, paramsDict):
+		"""
+		This method does nothing for the aperture case.
+		"""
+		pass
 

--- a/py/orbit/py_linac/lattice/__init__.py
+++ b/py/orbit/py_linac/lattice/__init__.py
@@ -18,6 +18,8 @@ from LinacApertureNodes import LinacApertureNode
 from LinacApertureNodes import CircleLinacApertureNode
 from LinacApertureNodes import EllipseLinacApertureNode
 from LinacApertureNodes import RectangleLinacApertureNode
+from LinacApertureNodes import LinacPhaseApertureNode
+from LinacApertureNodes import LinacEnergyApertureNode
 
 from LinacFieldOverlappingNodes import AxisField_and_Quad_RF_Gap
 from LinacFieldOverlappingNodes import OverlappingQuadsNode
@@ -44,6 +46,8 @@ __all__.append("LinacApertureNode")
 __all__.append("CircleLinacApertureNode")
 __all__.append("EllipseLinacApertureNode")
 __all__.append("RectangleLinacApertureNode")
+__all__.append("LinacPhaseApertureNode")
+__all__.append("LinacEnergyApertureNode")
 
 __all__.append("RF_Cavity")
 __all__.append("Sequence")

--- a/py/orbit/py_linac/lattice_modifications/quad_overlap_modifications_lib.py
+++ b/py/orbit/py_linac/lattice_modifications/quad_overlap_modifications_lib.py
@@ -156,19 +156,51 @@ def Replace_Quads_to_OverlappingQuads_Nodes(\
 				(node_pos_start,node_pos_end) = node_pos_dict[node]
 				delta = node_pos_end - pos_start
 				new_length = abs(node.getLength() - delta)
+				#print "debug start group node = ",node.getName()," node.getLength() - delta =",node.getLength() - delta
 				if(new_length > drift_length_tolerance):
-					node.setLength(new_length)
-					node.setPosition(node.getPosition() - delta/2)
-					new_nodes.append(node)
+					if(quad_group_ind > 0):
+						#---- we have to check that this node is not the end node of the previous quad group
+						#---- if it is true we have to skip it because we already accounted for this node
+						#---- earlier when we considered node at the end of the previous group
+						[quads_arr0,pos_start0,pos_end0,ind_start0,ind_end0] = quad_groups_and_ind_arr[quad_group_ind-1]
+						if(ind_start != ind_end0):
+							node_new = Drift(node.getName())
+							node_new .setLength(new_length)
+							node_new .setPosition(node.getPosition() - delta/2)
+							new_nodes.append(node_new)
+					else:
+						node_new = Drift(node.getName())
+						node_new .setLength(new_length)
+						node_new .setPosition(node.getPosition() - delta/2)
+						new_nodes.append(node_new)
 			node = nodes[ind_end]
 			if(isinstance(node,Drift)):
 				(node_pos_start,node_pos_end) = node_pos_dict[node]
 				delta = pos_end - node_pos_start 
 				new_length = abs(node.getLength() - delta)
+				#print "debug end   group node = ",node.getName()," node.getLength() - delta =",node.getLength() - delta
 				if(new_length > drift_length_tolerance):
-					node.setLength(new_length)
-					node.setPosition(node.getPosition() + delta/2)	
-					new_nodes.append(node)
+					if(quad_group_ind < n_groups - 1):
+						#---- we have to check that this node is not the start node of the next quad group
+						#---- if it is true we have to account for the cat in the length from this group also
+						[quads_arr1,pos_start1,pos_end1,ind_start1,ind_end1] = quad_groups_and_ind_arr[quad_group_ind+1]
+						if(ind_end == ind_start1):
+							delta1 = node_pos_end - pos_start1
+							new_length = abs(new_length - delta1)
+							node_new = Drift(node.getName())
+							node_new.setLength(new_length)
+							node_new.setPosition(node.getPosition() + delta/2 - delta1/2 )	
+							new_nodes.append(node_new)								
+						else:
+							node_new = Drift(node.getName())
+							node_new.setLength(new_length)
+							node_new.setPosition(node.getPosition() + delta/2)	
+							new_nodes.append(node_new)							
+					else:
+						node_new = Drift(node.getName())
+						node_new.setLength(new_length)
+						node_new.setPosition(node.getPosition() + delta/2)	
+						new_nodes.append(node_new)
 		#---- 2st STEP - nodes from the beginning to the first group of quads
 		[quads_arr,pos_start,pos_end,ind_start,ind_end] = quad_groups_and_ind_arr[0]
 		for node_ind in range(0,ind_start):

--- a/py/orbit/py_linac/linac_parsers/__init__.py
+++ b/py/orbit/py_linac/linac_parsers/__init__.py
@@ -3,6 +3,8 @@
 ##
 
 from sns_linac_lattice_factory import SNS_LinacLatticeFactory
+from jparc_linac_lattice_factory import JPARC_LinacLatticeFactory
 
 __all__ = []
 __all__.append("SNS_LinacLatticeFactory")
+__all__.append("JPARC_LinacLatticeFactory")

--- a/py/orbit/py_linac/linac_parsers/jparc_linac_lattice_factory.py
+++ b/py/orbit/py_linac/linac_parsers/jparc_linac_lattice_factory.py
@@ -1,0 +1,39 @@
+"""
+The JPARC Linac Lattice Factory generates the Linac Accelerator Lattice from the information
+inside of the XML input file. This structure of this file is very similar to SNS.
+The difference is the order of accelerator sequences. In JPARC file they are in  arbitrary order.
+The user will combine them on the application script level. The reason for this: JPARC linac
+has several different dump sequences, so the order check that exists in the SNS lattice factory 
+could fail for JPARC. It is responsibility of the user to check the order and names of the 
+sequences in the lattice.
+"""
+
+import os
+import sys
+import math
+
+from sns_linac_lattice_factory import SNS_LinacLatticeFactory
+
+class JPARC_LinacLatticeFactory(SNS_LinacLatticeFactory):
+	""" 
+	The JPARC Linac Lattice Factory generates the Linac Accelerator Lattice 
+	from the XML file of the specific structure. 
+	"""
+	def __init__(self):
+		SNS_LinacLatticeFactory.__init__(self)
+		
+		
+	def filterSequences_and_OptionalCheck(self,accSeq_da_arr,names):
+		"""
+		This method is overridden here.
+		This method will filter the sequences according to names list.
+		It returns the filtered array with data adapters with the names
+		that are in the names array.
+		"""
+		accSeq_da_fltr_arr = []
+		for name in names:
+			for accSeq_da in accSeq_da_arr:
+				if(accSeq_da.getName() == name):
+					accSeq_da_fltr_arr.append(accSeq_da)
+		return accSeq_da_fltr_arr
+				

--- a/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
+++ b/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
@@ -79,27 +79,8 @@ class SNS_LinacLatticeFactory():
 			orbitFinalize(msg)
 		#----- let's parse the XML DataAdaptor
 		accSeq_da_arr = acc_da.childAdaptors()
-		#let's check that the names in good order  ==start==
-		seqencesLocal = accSeq_da_arr
-		seqencesLocalNames = []
-		for seq_da in seqencesLocal:
-			seqencesLocalNames.append(seq_da.getName())
-		ind_old = -1
-		count = 0
-		for name in names:
-			ind = seqencesLocalNames.index(name)
-			if(ind < 0 or (count > 0 and ind != (ind_old + 1))):
-				msg = "The LinacLatticeFactory method getLinacAccLattice(names): sequence names array is wrong!"
-				msg = msg + os.linesep
-				msg = msg + "existing names=" + str(seqencesLocalNames)
-				msg = msg + os.linesep
-				msg = msg + "sequence names="+str(names)
-				orbitFinalize(msg)
-			ind_old = ind
-			count += 1
-		#	let's check that the names in good order  ==stop==			
-		ind_start = seqencesLocalNames.index(names[0])
-		accSeq_da_arr = accSeq_da_arr[ind_start:ind_start+len(names)]
+		#-----let's filter and check that the names in good order 
+		accSeq_da_arr = self.filterSequences_and_OptionalCheck(accSeq_da_arr,names)
 		#----make linac lattice
 		linacAccLattice = LinacAccLattice(acc_da.getName())
 		#There are the folowing possible types of elements in the linac tree:
@@ -404,6 +385,35 @@ class SNS_LinacLatticeFactory():
 		#------- finalize the lattice construction
 		linacAccLattice.initialize()
 		return linacAccLattice
+
+	def filterSequences_and_OptionalCheck(self,accSeq_da_arr,names):
+		"""
+		This method will filter the sequences according to names list
+		and check the order of sequences in names. 
+		All sequences should be in the right order. For SNS linac is 
+		just a linac. It returns the filtered array with data adapters
+		with the names in the names array.
+		"""
+		seqencesLocal = accSeq_da_arr
+		seqencesLocalNames = []
+		for seq_da in seqencesLocal:
+			seqencesLocalNames.append(seq_da.getName())
+		ind_old = -1
+		count = 0
+		for name in names:
+			ind = seqencesLocalNames.index(name)
+			if(ind < 0 or (count > 0 and ind != (ind_old + 1))):
+				msg = "The LinacLatticeFactory method getLinacAccLattice(names): sequence names array is wrong!"
+				msg = msg + os.linesep
+				msg = msg + "existing names=" + str(seqencesLocalNames)
+				msg = msg + os.linesep
+				msg = msg + "sequence names="+str(names)
+				orbitFinalize(msg)
+			ind_old = ind
+			count += 1		
+		ind_start = seqencesLocalNames.index(names[0])
+		accSeq_da_arr = accSeq_da_arr[ind_start:ind_start+len(names)]
+		return accSeq_da_arr
 
 	def makeDataAdaptorforLinacLattice(self,linacAccLattice):
 		"""

--- a/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
+++ b/py/orbit/py_linac/linac_parsers/sns_linac_lattice_factory.py
@@ -167,6 +167,10 @@ class SNS_LinacLatticeFactory():
 					if(params_da.hasAttribute("aperture") and params_da.hasAttribute("aprt_type")):
 						accNode.setParam("aprt_type",params_da.intValue("aprt_type"))
 						accNode.setParam("aperture",params_da.doubleValue("aperture"))
+					#---- possible parameters for PMQ description of the in Trace3D style
+					if(params_da.hasAttribute("radIn") and params_da.hasAttribute("radOut")):
+						accNode.setParam("radIn",params_da.doubleValue("radIn"))
+						accNode.setParam("radOut",params_da.doubleValue("radOut"))
 					accNode.setParam("pos",node_pos)
 					accSeq.addNode(accNode)
 				#------------BEND-----------------

--- a/py/orbit/py_linac/overlapping_fields/__init__.py
+++ b/py/orbit/py_linac/overlapping_fields/__init__.py
@@ -5,11 +5,15 @@
 from overlapping_quad_fields_lib import EngeFunction
 from overlapping_quad_fields_lib import AbstractQuadFieldSourceFunction
 from overlapping_quad_fields_lib import SimpleQuadFieldFunc
+from overlapping_quad_fields_lib import PMQ_Trace3D_Function
 
 from sns_enge_func_factory import SNS_EngeFunctionFactory
+from jparc_enge_func_factory import JPARC_EngeFunctionFactory
 
 __all__ = []    
 __all__.append("EngeFunction")
 __all__.append("AbstractQuadFieldSourceFunction")
 __all__.append("SimpleQuadFieldFunc")
+__all__.append("PMQ_Trace3D_Function")
 __all__.append("SNS_EngeFunctionFactory")
+__all__.append("JPARC_EngeFunctionFactory")

--- a/py/orbit/py_linac/overlapping_fields/jparc_enge_func_factory.py
+++ b/py/orbit/py_linac/overlapping_fields/jparc_enge_func_factory.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+#--------------------------------------------------------------
+# This is a Enge Function Factory specific for the J-PARC. Some 
+# Enge's function parameters are defined by the aperture and length,
+# and others are defined by the field distribution formula from Trace3D
+# documentation.
+#--------------------------------------------------------------
+
+import math
+import sys
+import os
+
+from overlapping_quad_fields_lib import PMQ_Trace3D_Function
+from overlapping_quad_fields_lib import EngeFunction
+from overlapping_quad_fields_lib import SimpleQuadFieldFunc
+	
+def JPARC_EngeFunctionFactory(quad):
+	"""
+	It generates the Enge's Function for J-PARC quads.
+	"""
+	name = quad.getName()
+	length_param = quad.getLength()		
+	#---- general PMQ function described in Trace3D documentation
+	if(quad.hasParam("radIn") and quad.hasParam("radOut")):
+		radIn = quad.getParam("radIn")
+		radOut = quad.getParam("radOut")
+		cutoff_level = 0.01
+		if(name == "LI_DTL1:DTQ01"): cutoff_level = 0.02
+		func = PMQ_Trace3D_Function(length_param,radIn,radOut,cutoff_level)
+		return func
+	#----- general Enge's Function
+	if(quad.hasParam("aperture")):
+		acceptance_diameter_param = quad.getParam("aperture")
+		cutoff_level = 0.01	
+		func = EngeFunction(length_param,acceptance_diameter_param,cutoff_level)
+		return func
+	else:
+		msg  = "SNS_EngeFunctionFactory Python function. "
+		msg += os.linesep
+		msg += "Cannot create the EngeFunction for the quad!"
+		msg += os.linesep
+		msg = msg + "quad name = " + 	quad.getName()	
+		msg = msg + os.linesep		
+		msg = msg + "It does not have the aperture parameter!"
+		msg = msg + os.linesep		
+		orbitFinalize(msg)
+	return None	

--- a/src/orbit/Apertures/EnergyAperture.cc
+++ b/src/orbit/Apertures/EnergyAperture.cc
@@ -1,0 +1,152 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   EnergyAperture::EnergyAperture
+//
+// Author: A. Shishlo
+// Date: 03/29/2017
+//
+// DESCRIPTION
+//   Constructs an aperture for the energy (relative to synch. part.) variable.
+//
+// PARAMETERS
+//   The class will remove particles (and put them into lost_bunch) from 
+//   the bunch whose energy (relative to synch. part.) is outside the specified min and 
+//   max values. This class mostly is intended to be used in linacs. 
+//   The energy is in GeV.
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+#include "EnergyAperture.hh"
+#include "SyncPart.hh"
+#include "OrbitConst.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+#include "ParticleAttributes.hh"
+
+/**
+ The EnergyAperture class constructor.
+ */
+EnergyAperture::EnergyAperture(): CppPyWrapper(NULL)
+{
+	minEnergy_ = -1.0e+36;
+	maxEnergy_ = +1.0e+36;
+	pos_ = 0.;
+}
+
+/**
+ The method sets the energy limits in GeV for particles in the bunch.
+ */
+void EnergyAperture::setEnergyLimits(double minEnergy, double maxEnergy){
+	minEnergy_ = minEnergy;
+	maxEnergy_ = maxEnergy;
+}
+
+/**
+ Returns the min limit of the particles' energy.
+ */
+double EnergyAperture::getMinEnergy(){
+	return minEnergy_; 
+}
+
+/**
+ Returns the max limit of the particles' energy.
+ */
+double EnergyAperture::getMaxEnergy(){
+	return maxEnergy_; 
+}
+
+/**
+ Sets the position of the Energy Aperture node.
+ */
+void EnergyAperture::setPosition(double position){
+	pos_ = position;
+}
+
+/**
+ Returns the position of the Energy Aperture node.
+ */
+double EnergyAperture::getPosition(){
+	return pos_;
+}
+
+/**
+ Removes particles with phases outside the energy limits and puts them
+ into the lost bunch is it exists.
+ */
+void EnergyAperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
+
+	bunch->compress();
+	if(lostbunch != NULL) lostbunch->compress();
+	double m_size = 0.;
+	int nParts = bunch->getSize();
+	double** coord = bunch->coordArr();
+	
+	ParticleAttributes* lostPartAttr = NULL;
+	
+	ParticleAttributes* partIdNumbAttr = NULL;
+	ParticleAttributes* partIdNumbInitAttr = NULL;
+	
+	ParticleAttributes* partMacroAttr = NULL;
+	ParticleAttributes* partMacroInitAttr = NULL;	
+	
+	if(lostbunch != NULL) {
+		if(lostbunch->hasParticleAttributes("LostParticleAttributes") <= 0){
+			std::map<std::string,double> params_dict;
+			lostbunch->addParticleAttributes("LostParticleAttributes",params_dict);
+		}
+		lostPartAttr = lostbunch->getParticleAttributes("LostParticleAttributes");
+		
+		
+		if(bunch->hasParticleAttributes("ParticleIdNumber") > 0){
+			partIdNumbInitAttr = bunch->getParticleAttributes("ParticleIdNumber");
+			if(lostbunch->hasParticleAttributes("ParticleIdNumber") <= 0){
+				std::map<std::string,double> params_dict;
+				lostbunch->addParticleAttributes("ParticleIdNumber",params_dict);
+				partIdNumbAttr = lostbunch->getParticleAttributes("ParticleIdNumber");
+			}	
+		}
+		
+		if(bunch->hasParticleAttributes("macrosize") > 0){
+			partMacroInitAttr = bunch->getParticleAttributes("macrosize");
+			if(lostbunch->hasParticleAttributes("macrosize") <= 0){
+				std::map<std::string,double> params_dict;
+				lostbunch->addParticleAttributes("macrosize",params_dict);
+				partMacroAttr = lostbunch->getParticleAttributes("macrosize");
+			}	
+		}	
+		
+		lostbunch->setMacroSize(bunch->getMacroSize());
+	}
+	
+	double dE = 0.;
+	for (int count = 0; count < nParts; count++){
+		dE = coord[count][5];
+		if(dE < minEnergy_ || dE > maxEnergy_){
+			if(lostbunch != NULL) {
+				lostbunch->addParticle(coord[count][0], coord[count][1], coord[count][2], coord[count][3], coord[count][4], coord[count][5]);
+				//pos_ is a position in lattice where particle is lost
+				lostPartAttr->attValue(lostbunch->getSize() - 1, 0) = pos_;
+				if(partIdNumbAttr != NULL){
+					partIdNumbAttr->attValue(lostbunch->getSize() - 1, 0) = partIdNumbInitAttr->attValue(count,0);
+				}
+				if(partMacroAttr != NULL){
+					partMacroAttr->attValue(lostbunch->getSize() - 1, 0) = partMacroInitAttr->attValue(count,0);
+				}
+			}
+			bunch->deleteParticleFast(count);
+		}
+	}
+	
+	//Update synchronous particle, compress bunch
+	bunch->compress();
+}
+
+	
+

--- a/src/orbit/Apertures/EnergyAperture.hh
+++ b/src/orbit/Apertures/EnergyAperture.hh
@@ -1,0 +1,80 @@
+#ifndef ENERGY_APERTURE_H
+#define ENERGY_APERTURE_H
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   EnergyAperture::EnergyAperture
+//
+// Author: A. Shishlo
+// Date: 03/29/2017
+//
+// DESCRIPTION
+//   Constructs an aperture for the energy (relative to synch. part.) variable.
+//
+// PARAMETERS
+//   The class will remove particles (and put them into lost_bunch) from 
+//   the bunch whose energy (relative to synch. part.) is outside the specified min and 
+//   max values. This class mostly is intended to be used in linacs. 
+//   The energy is in GeV.
+//
+///////////////////////////////////////////////////////////////////////////
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+#include "Bunch.hh"
+
+using namespace std;
+
+class EnergyAperture: public OrbitUtils::CppPyWrapper
+{
+  public:
+	
+  /**
+  The EnergyAperture class constructor.
+  */	
+  EnergyAperture();
+  
+  /**
+  The method sets the energy limits in GeV for particles in the bunch.
+  */
+  void setEnergyLimits(double minEnergy, double maxEnergy);
+  
+  /**
+  Returns the min limit of the particles' energy.
+  */
+  double getMinEnergy();
+  
+  /**
+  Returns the max limit of the particles' energy.
+  */
+  double getMaxEnergy();
+  
+  /**
+  Sets the position of the Energy Aperture node.
+  */
+  void setPosition(double position);
+  
+  /**
+  Returns the position of the Energy Aperture node.
+  */
+  double getPosition();
+  
+  /**
+  Removes particles with phases outside the energy limits and puts them
+  into the lost bunch is it exists.
+  */
+  void checkBunch(Bunch* bunch, Bunch* lostbunch);
+  
+  
+  protected:
+  	//EnergyAperture parameters
+  	double minEnergy_;
+  	double maxEnergy_;
+  	double pos_;
+  	
+};
+
+//end of ENERGY_APERTURE_H ifdef
+#endif
+

--- a/src/orbit/Apertures/PhaseAperture.cc
+++ b/src/orbit/Apertures/PhaseAperture.cc
@@ -1,0 +1,175 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   PhaseAperture::PhaseAperture
+//
+// Author: A. Shishlo
+// Date: 03/29/2017
+//
+// DESCRIPTION
+//   Constructs an aperture for the longitudinal direction.
+//
+// PARAMETERS
+//   The class will remove particles (and put them into lost_bunch) from 
+//   the bunch whose longitudinal phase is outside the specified min and 
+//   max phases. This class mostly is intended to be used in linacs. 
+//   The user have to specify the RF frequency to translate the longitudinal 
+//   position from meters to the phase in degrees.
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+#include "PhaseAperture.hh"
+#include "SyncPart.hh"
+#include "OrbitConst.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+#include "ParticleAttributes.hh"
+
+/**
+ The PhaseAperture class constructor. It needs the RF frequency in Hz to translate
+ from z coordinate in meters to phase in degrees.
+ */
+PhaseAperture::PhaseAperture(double frequency): CppPyWrapper(NULL)
+{
+	frequency_ = frequency;
+	minPhase_ = -1.0e+36;
+	maxPhase_ = +1.0e+36;
+	pos_ = 0.;
+}
+
+/**
+ The method sets the phase limits particles in the bunch. Phase limits are in degrees.
+ */
+void PhaseAperture::setPhaseLimits(double minPhase, double maxPhase){
+	minPhase_ = minPhase;
+	maxPhase_ = maxPhase;
+}
+
+/**
+ Returns the min limit of the particles' phases. Phase is in degrees.
+ */
+double PhaseAperture::getMinPhase(){
+	return minPhase_; 
+}
+
+/**
+ Returns the max limit of the particles' phases. Phase is in degrees.
+ */
+double PhaseAperture::getMaxPhase(){
+	return maxPhase_; 
+}
+
+/**
+ Sets the position of the Phase Aperture node.
+ */
+void PhaseAperture::setPosition(double position){
+	pos_ = position;
+}
+
+/**
+ Returns the position of the Phase Aperture node.
+ */
+double PhaseAperture::getPosition(){
+	return pos_;
+}
+
+/**
+ Sets the RF frequency of the Phase Aperture node in Hz.
+ */
+void PhaseAperture::setRfFrequency(double frequency){
+	frequency_ = frequency;
+}
+
+/**
+ Returns the RF frequency of the Phase Aperture node in Hz.
+ */
+double PhaseAperture::getRfFrequency(){
+	return frequency_;
+}
+
+/**
+ Removes particles with phases outside the phase limits and puts them
+ into the lost bunch is it exists.
+ */
+void PhaseAperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
+
+	bunch->compress();
+	if(lostbunch != NULL) lostbunch->compress();
+	double m_size = 0.;
+	int nParts = bunch->getSize();
+	double** coord = bunch->coordArr();
+	
+	ParticleAttributes* lostPartAttr = NULL;
+	
+	ParticleAttributes* partIdNumbAttr = NULL;
+	ParticleAttributes* partIdNumbInitAttr = NULL;
+	
+	ParticleAttributes* partMacroAttr = NULL;
+	ParticleAttributes* partMacroInitAttr = NULL;	
+	
+	if(lostbunch != NULL) {
+		if(lostbunch->hasParticleAttributes("LostParticleAttributes") <= 0){
+			std::map<std::string,double> params_dict;
+			lostbunch->addParticleAttributes("LostParticleAttributes",params_dict);
+		}
+		lostPartAttr = lostbunch->getParticleAttributes("LostParticleAttributes");
+		
+		
+		if(bunch->hasParticleAttributes("ParticleIdNumber") > 0){
+			partIdNumbInitAttr = bunch->getParticleAttributes("ParticleIdNumber");
+			if(lostbunch->hasParticleAttributes("ParticleIdNumber") <= 0){
+				std::map<std::string,double> params_dict;
+				lostbunch->addParticleAttributes("ParticleIdNumber",params_dict);
+				partIdNumbAttr = lostbunch->getParticleAttributes("ParticleIdNumber");
+			}	
+		}
+		
+		if(bunch->hasParticleAttributes("macrosize") > 0){
+			partMacroInitAttr = bunch->getParticleAttributes("macrosize");
+			if(lostbunch->hasParticleAttributes("macrosize") <= 0){
+				std::map<std::string,double> params_dict;
+				lostbunch->addParticleAttributes("macrosize",params_dict);
+				partMacroAttr = lostbunch->getParticleAttributes("macrosize");
+			}	
+		}	
+		
+		lostbunch->setMacroSize(bunch->getMacroSize());
+	}
+
+	double beta = bunch->getSyncPart()->getBeta();
+	double lambda = OrbitConst::c*beta/frequency_;
+	double z_to_phase_coeff = - 360./lambda;
+	double z = 0.;
+	double phase = 0.;
+	
+	for (int count = 0; count < nParts; count++){
+		z = coord[count][4];
+		phase = z*z_to_phase_coeff;
+		if(phase < minPhase_ || phase > maxPhase_){
+			if(lostbunch != NULL) {
+				lostbunch->addParticle(coord[count][0], coord[count][1], coord[count][2], coord[count][3], coord[count][4], coord[count][5]);
+				//pos_ is a position in lattice where particle is lost
+				lostPartAttr->attValue(lostbunch->getSize() - 1, 0) = pos_;
+				if(partIdNumbAttr != NULL){
+					partIdNumbAttr->attValue(lostbunch->getSize() - 1, 0) = partIdNumbInitAttr->attValue(count,0);
+				}
+				if(partMacroAttr != NULL){
+					partMacroAttr->attValue(lostbunch->getSize() - 1, 0) = partMacroInitAttr->attValue(count,0);
+				}
+			}
+			bunch->deleteParticleFast(count);
+		}
+	}
+	
+	//Update synchronous particle, compress bunch
+	bunch->compress();
+}
+
+	
+

--- a/src/orbit/Apertures/PhaseAperture.hh
+++ b/src/orbit/Apertures/PhaseAperture.hh
@@ -1,0 +1,93 @@
+#ifndef PHASE_APERTURE_H
+#define PHASE_APERTURE_H
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   PhaseAperture::PhaseAperture
+//
+// Author: A. Shishlo
+// Date: 03/29/2017
+//
+// DESCRIPTION
+//   Constructs an aperture for the longitudinal direction.
+//
+// PARAMETERS
+//   The class will remove particles (and put them into lost_bunch) from 
+//   the bunch whose longitudinal phase is outside the specified min and 
+//   max phases. This class mostly is intended to be used in linacs. 
+//   The user have to specify the RF frequency to translate the longitudinal 
+//   position from meters to the phase in degrees.
+//
+///////////////////////////////////////////////////////////////////////////
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+#include "Bunch.hh"
+
+using namespace std;
+
+class PhaseAperture: public OrbitUtils::CppPyWrapper
+{
+  public:
+	
+  /**
+  The PhaseAperture class constructor. It needs the RF frequency in Hz to translate
+  from z coordinate in meters to phase in degrees.
+  */	
+  PhaseAperture(double frequency);
+  
+  /**
+  The method sets the phase limits particles in the bunch. Phase limits are in degrees.
+  */
+  void setPhaseLimits(double minPhase, double maxPhase);
+  
+  /**
+  Returns the min limit of the particles' phases. Phase is in degrees.
+  */
+  double getMinPhase();
+  
+  /**
+  Returns the max limit of the particles' phases. Phase is in degrees.
+  */
+  double getMaxPhase();
+  
+  /**
+  Sets the position of the Phase Aperture node.
+  */
+  void setPosition(double position);
+  
+  /**
+  Returns the position of the Phase Aperture node.
+  */
+  double getPosition();
+  
+  /**
+  Sets the RF frequency of the Phase Aperture node in Hz.
+  */
+  void setRfFrequency(double frequency);
+  
+  /**
+  Returns the RF frequency of the Phase Aperture node in Hz.
+  */
+  double getRfFrequency();
+  
+  /**
+  Removes particles with phases outside the phase limits and puts them
+  into the lost bunch is it exists.
+  */  
+  void checkBunch(Bunch* bunch, Bunch* lostbunch);
+  
+  
+  protected:
+  	//PhaseAperture parameters
+  	double frequency_;
+  	double minPhase_;
+  	double maxPhase_;
+  	double pos_;
+  	
+};
+
+//end of PHASE_APERTURE_H ifdef
+#endif
+

--- a/src/orbit/Apertures/wrap_Aperture.cc
+++ b/src/orbit/Apertures/wrap_Aperture.cc
@@ -1,0 +1,173 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_aperture.hh"
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "Aperture.hh"
+
+namespace wrap_aperture{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ Aperture instance.
+      It never will be called directly.
+	*/
+	static PyObject* Aperture_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int Aperture_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
+
+	  int shape = 0.;
+	  double a = 0.;
+	  double b = 0.;
+	  double c = 0.;
+	  double d = 0.;
+	  double pos = 0.;
+	  
+	  //NO NEW OBJECT CREATED BY PyArg_ParseTuple! NO NEED OF Py_DECREF()
+	  if(!PyArg_ParseTuple(	args,"iddddd:arguments",&shape,&a,&b,&c,&d,&pos)){
+	  	ORBIT_MPI_Finalize("Aperture class constructor - cannot parse arguments! It should be (shape,a,b,c,d,pos)");
+	  }
+	  self->cpp_obj =  new Aperture(shape,a,b,c,d,pos);
+	  ((Aperture*) self->cpp_obj)->setPyWrapper((PyObject*) self);
+    return 0;
+  }
+  
+  /** Performs the collimation tracking of the bunch */
+  static PyObject* Aperture_checkBunch(PyObject *self, PyObject *args){
+	  Aperture* cpp_Aperture = (Aperture*)((pyORBIT_Object*) self)->cpp_obj;
+		PyObject* pyBunch;
+		PyObject* pyLostBunch;
+		int nVars = PyTuple_Size(args);
+		if(nVars == 2){
+			if(!PyArg_ParseTuple(args,"OO:checkBunch",&pyBunch, &pyLostBunch)){
+				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch, Bunch* bunch) - parameters are needed.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type) || !PyObject_IsInstance(pyLostBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch, Bunch* bunch) - method needs a Bunch.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			Bunch* cpp_lostbunch = (Bunch*) ((pyORBIT_Object*)pyLostBunch)->cpp_obj;
+			cpp_Aperture->checkBunch(cpp_bunch, cpp_lostbunch);
+		}
+		else{
+			if(!PyArg_ParseTuple(args,"O:checkBunch",&pyBunch)){
+				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch) - parameter is needed.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch) - method needs a Bunch.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			cpp_Aperture->checkBunch(cpp_bunch, NULL);			
+		}
+		Py_INCREF(Py_None);
+		return Py_None;
+  }
+		
+	/** Sets the position of the element in the lattice */
+	static PyObject* Aperture_setPosition(PyObject *self, PyObject *args){
+		Aperture* cpp_Aperture = (Aperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double position = 0;
+		if(!PyArg_ParseTuple(	args,"d:arguments",&position)){
+			ORBIT_MPI_Finalize("PyBunch - setPosition - cannot parse arguments! It should be (position)");
+		}
+		cpp_Aperture->setPosition(position);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+	
+  //-----------------------------------------------------
+  //destructor for python Aperture class (__del__ method).
+  //-----------------------------------------------------
+  static void Aperture_del(pyORBIT_Object* self){
+		//std::cerr<<"The Aperture __del__ has been called!"<<std::endl;
+		delete ((Aperture*)self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python Aperture wrapper class
+	// they will be vailable from python level
+	static PyMethodDef ApertureClassMethods[] = {
+		{ "checkBunch",				Aperture_checkBunch,    	METH_VARARGS,"Performs the aperture check of the bunch."},
+		{ "setPosition",			Aperture_setPosition,		METH_VARARGS,"Sets the position of the element in the lattice."},
+   {NULL}
+  };
+
+	static PyMemberDef ApertureClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python Aperture wrapper type definition
+	static PyTypeObject pyORBIT_Aperture_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"Aperture", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) Aperture_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The Aperture python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		ApertureClassMethods, /* tp_methods */
+		ApertureClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) Aperture_init, /* tp_init */
+		0, /* tp_alloc */
+		Aperture_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization Aperture class
+	//--------------------------------------------------
+
+	void initAperture(PyObject* module){
+		//check that the Aperture wrapper is ready
+		if (PyType_Ready(&pyORBIT_Aperture_Type) < 0) return;
+		Py_INCREF(&pyORBIT_Aperture_Type);
+		PyModule_AddObject(module, "Aperture", (PyObject *)&pyORBIT_Aperture_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_Aperture.hh
+++ b/src/orbit/Apertures/wrap_Aperture.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_APERTURE_HH_
+#define WRAP_ORBIT_APERTURE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_aperture{
+    void initAperture(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_APERTURE_HH_*/

--- a/src/orbit/Apertures/wrap_EnergyAperture.cc
+++ b/src/orbit/Apertures/wrap_EnergyAperture.cc
@@ -1,0 +1,192 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_aperture.hh"
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "EnergyAperture.hh"
+
+namespace wrap_energy_aperture{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ EnergyAperture instance.
+      It never will be called directly.
+	*/
+	static PyObject* EnergyAperture_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int EnergyAperture_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){	  
+	  self->cpp_obj =  new EnergyAperture();
+	  ((EnergyAperture*) self->cpp_obj)->setPyWrapper((PyObject*) self);
+    return 0;
+  }
+  
+  /** Performs the collimation tracking of the bunch */
+  static PyObject* EnergyAperture_checkBunch(PyObject *self, PyObject *args){
+	  EnergyAperture* cpp_EnergyAperture = (EnergyAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		PyObject* pyBunch;
+		PyObject* pyLostBunch;
+		int nVars = PyTuple_Size(args);
+		if(nVars == 2){
+			if(!PyArg_ParseTuple(args,"OO:checkBunch",&pyBunch, &pyLostBunch)){
+				ORBIT_MPI_Finalize("EnergyAperture - checkBunch(Bunch* bunch, Bunch* bunch) - parameters are needed.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type) || !PyObject_IsInstance(pyLostBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("EnergyAperture - checkBunch(Bunch* bunch, Bunch* bunch) - method needs a Bunch.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			Bunch* cpp_lostbunch = (Bunch*) ((pyORBIT_Object*)pyLostBunch)->cpp_obj;
+			cpp_EnergyAperture->checkBunch(cpp_bunch, cpp_lostbunch);
+		}
+		else{
+			if(!PyArg_ParseTuple(args,"O:checkBunch",&pyBunch)){
+				ORBIT_MPI_Finalize("EnergyAperture - checkBunch(Bunch* bunch) - parameter is needed.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("EnergyAperture - checkBunch(Bunch* bunch) - method needs a Bunch.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			cpp_EnergyAperture->checkBunch(cpp_bunch, NULL);			
+		}
+		Py_INCREF(Py_None);
+		return Py_None;
+  }
+		
+  /** Sets the min and max energy of the energy aperture class */
+	static PyObject* EnergyAperture_setMinMaxEnergy(PyObject *self, PyObject *args){
+		EnergyAperture* cpp_EnergyAperture = (EnergyAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double minEnergy = 0.;
+		double maxEnergy = 0.;
+		if(!PyArg_ParseTuple(	args,"dd:arguments",&minEnergy,&maxEnergy)){
+			ORBIT_MPI_Finalize("PyBunch - setMinMaxEnergy - cannot parse arguments! It should be (minEnergy,maxEnergy)");
+		}
+		cpp_EnergyAperture->setEnergyLimits(minEnergy,maxEnergy);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}  
+  
+  /** Returns the min and max energy of the energy aperture class */
+	static PyObject* EnergyAperture_getMinMaxEnergy(PyObject *self, PyObject *args){
+		EnergyAperture* cpp_EnergyAperture = (EnergyAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double minEnergy = cpp_EnergyAperture->getMinEnergy();
+		double maxEnergy = cpp_EnergyAperture->getMaxEnergy();
+		return Py_BuildValue("(dd)",minEnergy,maxEnergy);
+	}  
+
+  /** Returns the position of the element in the lattice */
+	static PyObject* EnergyAperture_getPosition(PyObject *self, PyObject *args){
+		EnergyAperture* cpp_EnergyAperture = (EnergyAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double position = cpp_EnergyAperture->getPosition();
+		return Py_BuildValue("d",position);
+	} 	
+	
+	/** Sets the position of the element in the lattice */
+	static PyObject* EnergyAperture_setPosition(PyObject *self, PyObject *args){
+		EnergyAperture* cpp_EnergyAperture = (EnergyAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double position = 0;
+		if(!PyArg_ParseTuple(	args,"d:arguments",&position)){
+			ORBIT_MPI_Finalize("PyBunch - setPosition - cannot parse arguments! It should be (position)");
+		}
+		cpp_EnergyAperture->setPosition(position);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+	
+  //-----------------------------------------------------
+  //destructor for python EnergyAperture class (__del__ method).
+  //-----------------------------------------------------
+  static void EnergyAperture_del(pyORBIT_Object* self){
+		//std::cerr<<"The EnergyAperture __del__ has been called!"<<std::endl;
+		delete ((EnergyAperture*)self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python EnergyAperture wrapper class
+	// they will be vailable from python level
+	static PyMethodDef EnergyApertureClassMethods[] = {
+		{ "checkBunch",				EnergyAperture_checkBunch,    	METH_VARARGS,"Performs the phase aperture check of the bunch."},
+		{ "setPosition",			EnergyAperture_setPosition,		  METH_VARARGS,"Sets the position of the element in lattice."},
+		{ "getPosition",			EnergyAperture_getPosition,		  METH_VARARGS,"Returns the position of the element in lattice."},
+		{ "setMinMaxEnergy",  EnergyAperture_setMinMaxEnergy, METH_VARARGS,"Sets the min and max energy of the energy aperture"},
+		{ "getMinMaxEnergy",	EnergyAperture_getMinMaxEnergy, METH_VARARGS,"Returns the min and max energy of the energy aperture"},
+   {NULL}
+  };
+
+	static PyMemberDef EnergyApertureClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python EnergyAperture wrapper type definition
+	static PyTypeObject pyORBIT_EnergyAperture_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"EnergyAperture", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) EnergyAperture_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The EnergyAperture python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		EnergyApertureClassMethods, /* tp_methods */
+		EnergyApertureClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) EnergyAperture_init, /* tp_init */
+		0, /* tp_alloc */
+		EnergyAperture_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization EnergyAperture class
+	//--------------------------------------------------
+
+	void initEnergyAperture(PyObject* module){
+		//check that the EnergyAperture wrapper is ready
+		if (PyType_Ready(&pyORBIT_EnergyAperture_Type) < 0) return;
+		Py_INCREF(&pyORBIT_EnergyAperture_Type);
+		PyModule_AddObject(module, "EnergyAperture", (PyObject *)&pyORBIT_EnergyAperture_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_EnergyAperture.hh
+++ b/src/orbit/Apertures/wrap_EnergyAperture.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_ENERGY_APERTURE_HH_
+#define WRAP_ORBIT_PHASE__APERTURE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_energy_aperture{
+    void initEnergyAperture(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_ENERGY_APERTURE_HH_*/

--- a/src/orbit/Apertures/wrap_PhaseAperture.cc
+++ b/src/orbit/Apertures/wrap_PhaseAperture.cc
@@ -1,0 +1,220 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_aperture.hh"
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "PhaseAperture.hh"
+
+namespace wrap_phase_aperture{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ PhaseAperture instance.
+      It never will be called directly.
+	*/
+	static PyObject* PhaseAperture_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int PhaseAperture_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
+
+	  double frequency = 402.5e+6;
+	  
+	  //NO NEW OBJECT CREATED BY PyArg_ParseTuple! NO NEED OF Py_DECREF()
+	  if(!PyArg_ParseTuple(	args,"d:arguments",&frequency)){
+	  	ORBIT_MPI_Finalize("PhaseAperture class constructor - cannot parse arguments! It should be (frequency)");
+	  }
+	  self->cpp_obj =  new PhaseAperture(frequency);
+	  ((PhaseAperture*) self->cpp_obj)->setPyWrapper((PyObject*) self);
+    return 0;
+  }
+  
+  /** Performs the collimation tracking of the bunch */
+  static PyObject* PhaseAperture_checkBunch(PyObject *self, PyObject *args){
+	  PhaseAperture* cpp_PhaseAperture = (PhaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		PyObject* pyBunch;
+		PyObject* pyLostBunch;
+		int nVars = PyTuple_Size(args);
+		if(nVars == 2){
+			if(!PyArg_ParseTuple(args,"OO:checkBunch",&pyBunch, &pyLostBunch)){
+				ORBIT_MPI_Finalize("PhaseAperture - checkBunch(Bunch* bunch, Bunch* bunch) - parameters are needed.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type) || !PyObject_IsInstance(pyLostBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("PhaseAperture - checkBunch(Bunch* bunch, Bunch* bunch) - method needs a Bunch.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			Bunch* cpp_lostbunch = (Bunch*) ((pyORBIT_Object*)pyLostBunch)->cpp_obj;
+			cpp_PhaseAperture->checkBunch(cpp_bunch, cpp_lostbunch);
+		}
+		else{
+			if(!PyArg_ParseTuple(args,"O:checkBunch",&pyBunch)){
+				ORBIT_MPI_Finalize("PhaseAperture - checkBunch(Bunch* bunch) - parameter is needed.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("PhaseAperture - checkBunch(Bunch* bunch) - method needs a Bunch.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			cpp_PhaseAperture->checkBunch(cpp_bunch, NULL);			
+		}
+		Py_INCREF(Py_None);
+		return Py_None;
+  }
+		
+  /** Sets the min and max phases of the phase aperture class */
+	static PyObject* PhaseAperture_setMinMaxPhase(PyObject *self, PyObject *args){
+		PhaseAperture* cpp_PhaseAperture = (PhaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double minPhase = 0.;
+		double maxPhase = 0.;
+		if(!PyArg_ParseTuple(	args,"dd:arguments",&minPhase,&maxPhase)){
+			ORBIT_MPI_Finalize("PyBunch - setMinMaxPhase - cannot parse arguments! It should be (minPhase,maxPhase)");
+		}
+		cpp_PhaseAperture->setPhaseLimits(minPhase,maxPhase);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}  
+  
+  /** Returns the min and max phases of the phase aperture class */
+	static PyObject* PhaseAperture_getMinMaxPhase(PyObject *self, PyObject *args){
+		PhaseAperture* cpp_PhaseAperture = (PhaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double minPhase = cpp_PhaseAperture->getMinPhase();
+		double maxPhase = cpp_PhaseAperture->getMaxPhase();
+		return Py_BuildValue("(dd)",minPhase,maxPhase);
+	}  
+  
+  /** Returns the RF frequency of the phase aperture class */
+	static PyObject* PhaseAperture_getRfFrequency(PyObject *self, PyObject *args){
+		PhaseAperture* cpp_PhaseAperture = (PhaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double frequency = cpp_PhaseAperture->getRfFrequency();
+		return Py_BuildValue("d",frequency);
+	} 
+  
+ 	/** Sets the RF frequency of the phase aperture class */
+	static PyObject* PhaseAperture_setRfFrequency(PyObject *self, PyObject *args){
+		PhaseAperture* cpp_PhaseAperture = (PhaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double frequency = 0.;
+		if(!PyArg_ParseTuple(	args,"d:arguments",&frequency)){
+			ORBIT_MPI_Finalize("PyBunch - setRfFrequency - cannot parse arguments! It should be (frequency)");
+		}
+		cpp_PhaseAperture->setRfFrequency(frequency);
+		Py_INCREF(Py_None);
+		return Py_None;
+	} 
+  
+  /** Returns the position of the element in the lattice */
+	static PyObject* PhaseAperture_getPosition(PyObject *self, PyObject *args){
+		PhaseAperture* cpp_PhaseAperture = (PhaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double position = cpp_PhaseAperture->getPosition();
+		return Py_BuildValue("d",position);
+	} 	
+	
+	/** Sets the position of the element in the lattice */
+	static PyObject* PhaseAperture_setPosition(PyObject *self, PyObject *args){
+		PhaseAperture* cpp_PhaseAperture = (PhaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double position = 0;
+		if(!PyArg_ParseTuple(	args,"d:arguments",&position)){
+			ORBIT_MPI_Finalize("PyBunch - setPosition - cannot parse arguments! It should be (position)");
+		}
+		cpp_PhaseAperture->setPosition(position);
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+	
+  //-----------------------------------------------------
+  //destructor for python PhaseAperture class (__del__ method).
+  //-----------------------------------------------------
+  static void PhaseAperture_del(pyORBIT_Object* self){
+		//std::cerr<<"The PhaseAperture __del__ has been called!"<<std::endl;
+		delete ((PhaseAperture*)self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python PhaseAperture wrapper class
+	// they will be vailable from python level
+	static PyMethodDef PhaseApertureClassMethods[] = {
+		{ "checkBunch",				PhaseAperture_checkBunch,    	 METH_VARARGS,"Performs the phase aperture check of the bunch."},
+		{ "setPosition",			PhaseAperture_setPosition,		 METH_VARARGS,"Sets the position of the element in lattice."},
+		{ "getPosition",			PhaseAperture_getPosition,		 METH_VARARGS,"Returns the position of the element in lattice."},
+		{ "setMinMaxPhase",  PhaseAperture_setMinMaxPhase, METH_VARARGS,"Sets the min and max phases of the phase aperture"},
+		{ "getMinMaxPhase",	PhaseAperture_getMinMaxPhase, METH_VARARGS,"Returns the min and max phases of the phase aperture"},
+		{ "getRfFrequency",	  PhaseAperture_getRfFrequency,	 METH_VARARGS,"Returns the RF frequency of the phase aperture"},
+		{ "setRfFrequency",		PhaseAperture_setRfFrequency,	 METH_VARARGS,"Sets the RF frequency of the phase aperture"},	
+   {NULL}
+  };
+
+	static PyMemberDef PhaseApertureClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python PhaseAperture wrapper type definition
+	static PyTypeObject pyORBIT_PhaseAperture_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"PhaseAperture", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) PhaseAperture_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The PhaseAperture python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		PhaseApertureClassMethods, /* tp_methods */
+		PhaseApertureClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) PhaseAperture_init, /* tp_init */
+		0, /* tp_alloc */
+		PhaseAperture_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization PhaseAperture class
+	//--------------------------------------------------
+
+	void initPhaseAperture(PyObject* module){
+		//check that the PhaseAperture wrapper is ready
+		if (PyType_Ready(&pyORBIT_PhaseAperture_Type) < 0) return;
+		Py_INCREF(&pyORBIT_PhaseAperture_Type);
+		PyModule_AddObject(module, "PhaseAperture", (PyObject *)&pyORBIT_PhaseAperture_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_PhaseAperture.hh
+++ b/src/orbit/Apertures/wrap_PhaseAperture.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_PHASE_APERTURE_HH_
+#define WRAP_ORBIT_PHASE__APERTURE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_phase_aperture{
+    void initPhaseAperture(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_PHASE_APERTURE_HH_*/

--- a/src/orbit/Apertures/wrap_aperture.cc
+++ b/src/orbit/Apertures/wrap_aperture.cc
@@ -2,177 +2,33 @@
 #include "pyORBIT_Object.hh"
 
 #include "wrap_aperture.hh"
+
+#include "wrap_Aperture.hh"
+#include "wrap_PhaseAperture.hh"
+#include "wrap_EnergyAperture.hh"
+
 #include "wrap_bunch.hh"
 
 #include <iostream>
 
-#include "Aperture.hh"
-
 namespace wrap_aperture{
-
-  void error(const char* msg){ ORBIT_MPI_Finalize(msg); }
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-	/** 
-	Constructor for python class wrapping c++ Aperture instance.
-      It never will be called directly.
-	*/
-	static PyObject* Aperture_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
-		pyORBIT_Object* self;
-		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
-		self->cpp_obj = NULL;
-		return (PyObject *) self;
-	}
-	
-  /** This is implementation of the __init__ method */
-  static int Aperture_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
-
-	  int shape = 0.;
-	  double a = 0.;
-	  double b = 0.;
-	  double c = 0.;
-	  double d = 0.;
-	  double pos = 0.;
-	  
-	  //NO NEW OBJECT CREATED BY PyArg_ParseTuple! NO NEED OF Py_DECREF()
-	  if(!PyArg_ParseTuple(	args,"iddddd:arguments",&shape,&a,&b,&c,&d,&pos)){
-		  error("PyBunch - addParticle - cannot parse arguments! It should be (shape,a,b,c,d,pos)");
-	  }
-	  self->cpp_obj =  new Aperture(shape,a,b,c,d,pos);
-	  ((Aperture*) self->cpp_obj)->setPyWrapper((PyObject*) self);
-    return 0;
-  }
-  
-	
-  /** Performs the collimation tracking of the bunch */
-  static PyObject* Aperture_checkBunch(PyObject *self, PyObject *args){
-	  Aperture* cpp_Aperture = (Aperture*)((pyORBIT_Object*) self)->cpp_obj;
-		PyObject* pyBunch;
-		PyObject* pyLostBunch;
-		int nVars = PyTuple_Size(args);
-		if(nVars == 2){
-			if(!PyArg_ParseTuple(args,"OO:checkBunch",&pyBunch, &pyLostBunch)){
-				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch, Bunch* bunch) - parameters are needed.");
-			}
-			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
-			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type) || !PyObject_IsInstance(pyLostBunch,pyORBIT_Bunch_Type)){
-				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch, Bunch* bunch) - method needs a Bunch.");
-			}
-			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
-			Bunch* cpp_lostbunch = (Bunch*) ((pyORBIT_Object*)pyLostBunch)->cpp_obj;
-			cpp_Aperture->checkBunch(cpp_bunch, cpp_lostbunch);
-		}
-		else{
-			if(!PyArg_ParseTuple(args,"O:checkBunch",&pyBunch)){
-				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch) - parameter is needed.");
-			}
-			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
-			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
-				ORBIT_MPI_Finalize("Aperture - checkBunch(Bunch* bunch) - method needs a Bunch.");
-			}
-			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
-			cpp_Aperture->checkBunch(cpp_bunch, NULL);			
-		}
-		Py_INCREF(Py_None);
-		return Py_None;
-  }
-		
-
-	/** Sets the position of the element in the lattice */
-	static PyObject* Aperture_setPosition(PyObject *self, PyObject *args){
-		Aperture* cpp_Aperture = (Aperture*)((pyORBIT_Object*) self)->cpp_obj;
-		double position = 0;
-		if(!PyArg_ParseTuple(	args,"d:arguments",&position)){
-			error("PyBunch - setPosition - cannot parse arguments! It should be (position)");
-		}
-		cpp_Aperture->setPosition(position);
-		Py_INCREF(Py_None);
-		return Py_None;
-	}
-	
-	
-	
-  //-----------------------------------------------------
-  //destructor for python Aperture class (__del__ method).
-  //-----------------------------------------------------
-  static void Aperture_del(pyORBIT_Object* self){
-		//std::cerr<<"The Aperture __del__ has been called!"<<std::endl;
-		delete ((Aperture*)self->cpp_obj);
-		self->ob_type->tp_free((PyObject*)self);
-  }
-	
-	// definition of the methods of the python Aperture wrapper class
-	// they will be vailable from python level
-	static PyMethodDef ApertureClassMethods[] = {
-		{ "checkBunch",				Aperture_checkBunch,    	METH_VARARGS,"Performs the aperture check of the bunch."},
-		{ "setPosition",			Aperture_setPosition,		METH_VARARGS,"Sets the position of the element in the lattice."},
-   {NULL}
-  };
-
-	static PyMemberDef ApertureClassMembers [] = {
-		{NULL}
-	};
-	
-	
-	//new python Aperture wrapper type definition
-	static PyTypeObject pyORBIT_Aperture_Type = {
-		PyObject_HEAD_INIT(NULL)
-		0, /*ob_size*/
-		"Aperture", /*tp_name*/
-		sizeof(pyORBIT_Object), /*tp_basicsize*/
-		0, /*tp_itemsize*/
-		(destructor) Aperture_del , /*tp_dealloc*/
-		0, /*tp_print*/
-		0, /*tp_getattr*/
-		0, /*tp_setattr*/
-		0, /*tp_compare*/
-		0, /*tp_repr*/
-		0, /*tp_as_number*/
-		0, /*tp_as_sequence*/
-		0, /*tp_as_mapping*/
-		0, /*tp_hash */
-		0, /*tp_call*/
-		0, /*tp_str*/
-		0, /*tp_getattro*/
-		0, /*tp_setattro*/
-		0, /*tp_as_buffer*/
-		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-		"The Aperture python wrapper", /* tp_doc */
-		0, /* tp_traverse */
-		0, /* tp_clear */
-		0, /* tp_richcompare */
-		0, /* tp_weaklistoffset */
-		0, /* tp_iter */
-		0, /* tp_iternext */
-		ApertureClassMethods, /* tp_methods */
-		ApertureClassMembers, /* tp_members */
-		0, /* tp_getset */
-		0, /* tp_base */
-		0, /* tp_dict */
-		0, /* tp_descr_get */
-		0, /* tp_descr_set */
-		0, /* tp_dictoffset */
-		(initproc) Aperture_init, /* tp_init */
-		0, /* tp_alloc */
-		Aperture_new, /* tp_new */
-	};	
 	
   static PyMethodDef ApertureModuleMethods[] = { {NULL,NULL} };	
   
 	//--------------------------------------------------
-	//Initialization Aperture of the pyBunchAperture class
+	//Initialization aperture module
 	//--------------------------------------------------
 
 	void initaperture(){
-		//check that the Aperture wrapper is ready
-		if (PyType_Ready(&pyORBIT_Aperture_Type) < 0) return;
-		Py_INCREF(&pyORBIT_Aperture_Type);
 		//create new module
 		PyObject* module = Py_InitModule("aperture",ApertureModuleMethods);
-		PyModule_AddObject(module, "Aperture", (PyObject *)&pyORBIT_Aperture_Type);			
+		wrap_aperture::initAperture(module);
+		wrap_phase_aperture::initPhaseAperture(module);
+		wrap_energy_aperture::initEnergyAperture(module);
 	}
 
 #ifdef __cplusplus

--- a/src/orbit/Apertures/wrap_aperture.cc
+++ b/src/orbit/Apertures/wrap_aperture.cc
@@ -160,8 +160,8 @@ extern "C" {
 		Aperture_new, /* tp_new */
 	};	
 	
-	
-	
+  static PyMethodDef ApertureModuleMethods[] = { {NULL,NULL} };	
+  
 	//--------------------------------------------------
 	//Initialization Aperture of the pyBunchAperture class
 	//--------------------------------------------------
@@ -171,7 +171,7 @@ extern "C" {
 		if (PyType_Ready(&pyORBIT_Aperture_Type) < 0) return;
 		Py_INCREF(&pyORBIT_Aperture_Type);
 		//create new module
-		PyObject* module = Py_InitModule("aperture",ApertureClassMethods);
+		PyObject* module = Py_InitModule("aperture",ApertureModuleMethods);
 		PyModule_AddObject(module, "Aperture", (PyObject *)&pyORBIT_Aperture_Type);			
 	}
 

--- a/src/orbit/Apertures/wrap_aperture.hh
+++ b/src/orbit/Apertures/wrap_aperture.hh
@@ -1,5 +1,5 @@
-#ifndef WRAP_ORBIT_APERTURE_HH_
-#define WRAP_ORBIT_APERTURE_HH_
+#ifndef WRAP_ORBIT_APERTURE_MODULE_HH_
+#define WRAP_ORBIT_APERTURE_MODULE__HH_
 
 #include "Python.h"
 
@@ -15,4 +15,4 @@ extern "C" {
 }
 #endif
 
-#endif /*WRAP_ORBIT_APERTURE_HH_*/
+#endif /*WRAP_ORBIT_APERTURE_MODULE__HH_*/

--- a/src/orbit/ParticlesAttributes/ParticleAttributesFactory.cc
+++ b/src/orbit/ParticlesAttributes/ParticleAttributesFactory.cc
@@ -26,6 +26,7 @@
 #include "LostParticleAttributes.hh"
 #include "ParticlePhaseAttributes.hh"
 #include "ParticleIdNumber.hh"
+#include "ParticleInitialCoordinates.hh"
 
 ParticleAttributesFactory::ParticleAttributesFactory()
 {
@@ -174,8 +175,11 @@ ParticleAttributes* ParticleAttributesFactory::getParticleAttributesInstance(
 			}
 		}
 	}
-  	
-  
+
+	if(name == "ParticleInitialCoordinates"){
+		part_atrs = new ParticleInitialCoordinates(bunch);
+	}	
+	
 	if(part_atrs == NULL) {
 		if(rank_MPI == 0){
 			std::cerr << "ParticleAttributesFactory::getParticleAttributesInstance(const string name, Bunch* bunch)"<< std::endl;

--- a/src/orbit/ParticlesAttributes/ParticleInitialCoordinates.cc
+++ b/src/orbit/ParticlesAttributes/ParticleInitialCoordinates.cc
@@ -1,0 +1,38 @@
+//////////////////////////////// -*- C++ -*- //////////////////////////////
+//
+// FILE NAME
+//   ParticleInitialCoordinates.cc
+//
+// AUTHOR
+//    A. Shishlo
+//
+// CREATED
+//    03/27/2017
+//
+// DESCRIPTION
+//    A subclass of a ParticleAttributes class that keeps the initial
+//    coordinates of the particles. This attributes will be used for 
+//    different purposes like:
+//    1. calculations of the acceptance phase space region for particles that
+//       reached a particular point at the lattice. The initial coordinates 
+//       should be put into these attributes before tracking.
+//    2. Calculation of the transport matrix between the origin (place were 
+//       initial coordinates were saved in these attributes) and the another
+//       point in the lattice.
+//
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include "Bunch.hh"
+#include "ParticleInitialCoordinates.hh"
+
+ParticleInitialCoordinates::ParticleInitialCoordinates(Bunch* bunch):
+  ParticleAttributes(bunch,6)
+{
+  cl_name_ = "ParticleInitialCoordinates";
+  attrDescr = "Initial Coordinates";
+}
+
+ParticleInitialCoordinates::~ParticleInitialCoordinates()
+{
+}

--- a/src/orbit/ParticlesAttributes/ParticleInitialCoordinates.hh
+++ b/src/orbit/ParticlesAttributes/ParticleInitialCoordinates.hh
@@ -1,0 +1,57 @@
+//////////////////////////////// -*- C++ -*- //////////////////////////////
+//
+// FILE NAME
+//   ParticleInitialCoordinates.cc
+//
+// AUTHOR
+//    A. Shishlo
+//
+// CREATED
+//    03/27/2017
+//
+// DESCRIPTION
+//    A subclass of a ParticleAttributes class that keeps the initial
+//    coordinates of the particles. This attributes will be used for 
+//    different purposes like:
+//    1. calculations of the acceptance phase space region for particles that
+//       reached a particular point at the lattice. The initial coordinates 
+//       should be put into these attributes before tracking.
+//    2. Calculation of the transport matrix between the origin (place were 
+//       initial coordinates were saved in these attributes) and the another
+//       point in the lattice.
+//
+//
+///////////////////////////////////////////////////////////////////////////
+#ifndef INITIAL_PARTICLE_COORDINATES_HH_
+#define INITIAL_PARTICLE_COORDINATES_HH_
+
+///////////////////////////////////////////////////////////////////////////
+//
+// INCLUDE FILES
+//
+///////////////////////////////////////////////////////////////////////////
+#include <string>
+#include "ParticleAttributes.hh"
+
+class ParticleInitialCoordinates : public ParticleAttributes
+{
+public:
+	
+	/** 
+	   A subclass of a ParticleAttributes class that keeps the initial
+	   coordinates of the particles.
+	*/
+	ParticleInitialCoordinates(Bunch* bunch);
+	
+  ~ParticleInitialCoordinates();
+
+};
+
+///////////////////////////////////////////////////////////////////////////
+//
+// END OF FILE
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+#endif /*INITIAL_PARTICLE_COORDINATES_HH_*/

--- a/src/utils/bunch/InitialCoordsAttrFunctions.cc
+++ b/src/utils/bunch/InitialCoordsAttrFunctions.cc
@@ -1,0 +1,369 @@
+//////////////////////////////// -*- C++ -*- //////////////////////////////
+//
+// FILE NAME
+//   InitialCoordsAttrFunctions.cc
+//
+// AUTHOR
+//    A. Shishlo
+//
+// CREATED
+//    03/27/2017
+//
+// DESCRIPTION
+//    A set of functions for bunches with the ParticleInitialCoordinates attributes.
+//    At this moment there are following functions:
+//
+//    1. A function that will copy coordinates of the particles to 
+//    the 6D initial coordinates Attribute (ParticleInitialCoordinates).
+//    
+//    void copyCoordsToInitCoordsAttr(Bunch* bunch);
+//
+//    2. Function that swaps init and existing 6D coordinates:
+//
+//    void swapInitCoordsAttrAndCoords(Bunch* bunch);
+//
+//    3. transport_mtrx_from_init_coords(bunch_in, Matrix* A_mtr)
+//    4. transport_mtrx_from_init_coords(bunch_in, Matrix* A_mtr, int appl_twiss_x, int appl_twiss_y, int appl_twiss_z)
+//    These functions will fill out the A_mtr that will be a transport matrix between
+//    initial coordinates and 6D coordinates.
+//    
+//    5. This function will apply weights for macro-size of each particle according to the 
+//    value wx = exp(-(x^2+(alphax*x+betax*x')^2)/(2*(betax*emittancex)) etc. This function
+//    is used inside the function 4.
+//
+//    void apply_twiss_weights_for_init_coords(Bunch* bunch,int appl_x,int appl_y,int appl_z);	
+//
+//    Before using these functions it is recommended to remove particles far away from the center
+//    of the phase space by using functions from TwissFilteringFunctions.cc
+//    Function 3 assumes the equal weights for all macro-particles, and 4 uses weights according
+//    wx = exp(-(x^2+(alphax*x+betax*x')^2)/(2*(betax*emittancex)) etc.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include <algorithm>    // std::sort
+#include <vector>       // std::vector
+
+#include "InitialCoordsAttrFunctions.hh"
+#include "ParticleInitialCoordinates.hh"
+#include "ParticleMacroSize.hh"
+
+#include "BufferStore.hh"
+#include "MatrixOperations.hh"
+#include "BunchTwissAnalysis.hh"
+
+#include "orbit_mpi.hh"
+
+namespace OrbitUtils{
+	
+	/** 
+	  A function that will copy coordinates of the particles to 
+	  the 6D initial coordinates Attribute (ParticleInitialCoordinates).
+	  */	
+	void copyCoordsToInitCoordsAttr(Bunch* bunch){
+		if(bunch->hasParticleAttributes("ParticleInitialCoordinates") == 0){
+			std::map<std::string,double> params_dict;
+			bunch->addParticleAttributes("ParticleInitialCoordinates",params_dict);
+		}
+		ParticleInitialCoordinates* partAttr = (ParticleInitialCoordinates*) bunch->getParticleAttributes("ParticleInitialCoordinates");
+		int n_parts = bunch->getSize();
+		double** coordArr = bunch->coordArr();
+		for(int i=0; i<n_parts; ++i){
+			for(int j=0; j < 6; ++j){
+				partAttr->attValue(i,j) = coordArr[i][j];
+			}
+		}
+	}
+	
+	/** 
+	  A function that will swap the initial coordinates Attribute 
+	  (ParticleInitialCoordinates) and the 6D coordinates of the particles.
+	  */
+	void swapInitCoordsAttrAndCoords(Bunch* bunch){
+		if(bunch->hasParticleAttributes("ParticleInitialCoordinates") == 0){
+			std::map<std::string,double> params_dict;
+			bunch->addParticleAttributes("ParticleInitialCoordinates",params_dict);
+		}
+		ParticleInitialCoordinates* partAttr = (ParticleInitialCoordinates*) bunch->getParticleAttributes("ParticleInitialCoordinates");
+		int n_parts = bunch->getSize();
+		double** coordArr = bunch->coordArr();
+		double val = 0.;
+		for(int i=0; i<n_parts; ++i){
+			for(int j=0; j < 6; ++j){
+				val = coordArr[i][j];
+				coordArr[i][j] = partAttr->attValue(i,j);
+				partAttr->attValue(i,j) = val;
+			}
+		}		
+	}
+		
+	/** 
+	  Calculates transport matrix A: x_out = A*x_in +b. A is a 7x7 matrix. 
+		The last column of A is the b vector.
+	  It returns 0 if unsuccessful or the size of the statistics otherwise.
+	  The function uses the initial coordinates attributes as x_in and the usual
+	  coordinates as x_out.
+	*/	
+	int transport_mtrx_from_init_coords(Bunch* bunch, Matrix* A_mtr){
+		return transport_mtrx_from_init_coords(bunch,A_mtr,0,0,0);
+	}
+	
+	/** A function analyzes the bunch with initail coords attributes assuming the vectors of coordinates 
+	    transformation x_out = A*x_in + b, where x_in the initial coordinates,
+			and x_out final. The results are matrix A (7x7) with the last column as a vector b.
+			It returns 0 if unsuccessful or the size of the statistics otherwise.
+	*/
+	int transport_mtrx_from_init_coords(Bunch* bunch, Matrix* A_mtr, int appl_twiss_x, int appl_twiss_y, int appl_twiss_z){
+		
+		int size_MPI,rank_MPI;
+		ORBIT_MPI_Comm_size(bunch->getMPI_Comm_Local()->comm, &size_MPI);
+		ORBIT_MPI_Comm_rank(bunch->getMPI_Comm_Local()->comm, &rank_MPI);	
+		
+		if(bunch->hasParticleAttributes("ParticleInitialCoordinates") == 0){
+			if(rank_MPI == 0){
+				std::cerr << "OrbitUtils::bunch_utils_functions::transport_mtrx_from_init_coords(...) function"<< std::endl;
+				std::cerr << "There is no ParticleAttributes  in Bunch with this name."<< std::endl;
+				std::cerr << "Attr. name:"<<" ParticleInitialCoordinates "<< std::endl;
+			}
+			ORBIT_MPI_Finalize();		
+		}
+		
+		if(A_mtr->rows() != 7 || A_mtr->columns() != 7){
+			if(rank_MPI == 0){
+				std::cerr << "OrbitUtils::bunch_utils_functions::transport_mtrx_init_coords(...) function"<< std::endl;
+				std::cerr << "Matix have wrong size (not 7x7)!"<< std::endl;
+				std::cerr << "Matrix A is:"<<A_mtr->rows()<<"x"<<A_mtr->columns()<< std::endl;
+			}
+			ORBIT_MPI_Finalize();				
+		}		
+		
+		//---------------fill out the temporary bunches
+		Bunch* b_tmp = new Bunch();
+		bunch->copyBunchTo(b_tmp); 
+		ParticleInitialCoordinates* partInitCoordsAttr = (ParticleInitialCoordinates*) b_tmp->getParticleAttributes("ParticleInitialCoordinates");
+		
+		int n_parts =  b_tmp->getSize();
+		int n_parts_global = b_tmp->getSizeGlobal();		
+		double total_macrosize = 1.0*n_parts;
+		
+		//apply Twiss Gaussian weights to microsize. It will add macrosize Attr. if it does not exist
+		apply_twiss_weights_for_init_coords(b_tmp,appl_twiss_x,appl_twiss_y,appl_twiss_z);
+		
+		ParticleMacroSize* partMacroSizeAttr_tmp = NULL;
+		if(b_tmp->hasParticleAttributes("macrosize") != 0){
+			partMacroSizeAttr_tmp  = (ParticleMacroSize*) b_tmp->getParticleAttributes("macrosize");
+			//apply weights if the Macrosize particle attr. is defined 
+			total_macrosize = 0.;
+			for(int ind = 0; ind < n_parts; ind++){
+				double m_size = partMacroSizeAttr_tmp->macrosize(ind);
+				total_macrosize += m_size;
+				for (int i = 0; i < 6; i++){
+					b_tmp->coordArr()[ind][i] *= m_size;
+					partInitCoordsAttr->attValue(ind,i) *= m_size;
+				}			
+			}
+		}		
+
+		//-------------analysis of the temporary bunches
+		A_mtr->zero();
+		if(n_parts_global > 6){
+			
+			int buff_index0 = -1;
+			int buff_index1 = -1;
+			int buff_index2 = -1;
+			int buff_index3 = -1;
+			int buff_index4 = -1;
+			int buff_index5 = -1;		
+			double* arr_avg  = BufferStore::getBufferStore()->getFreeDoubleArr(buff_index0,6);
+			double* arr_avg_mpi  = BufferStore::getBufferStore()->getFreeDoubleArr(buff_index1,6);
+			double* arr_init_avg  = BufferStore::getBufferStore()->getFreeDoubleArr(buff_index2,6);
+			double* arr_init_avg_mpi  = BufferStore::getBufferStore()->getFreeDoubleArr(buff_index3,6);			
+			double* mtrx_arr  = BufferStore::getBufferStore()->getFreeDoubleArr(buff_index4,36);
+			double* mtrx_arr_mpi = BufferStore::getBufferStore()->getFreeDoubleArr(buff_index5,36);	
+			double total_macrosize_mpi = 0.;
+			
+			for (int i = 0; i < 6; i++){
+				arr_avg[i] = 0.;
+				arr_init_avg[i] = 0.;
+			}
+			for(int ind = 0; ind < n_parts; ind++){
+				for (int i = 0; i < 6; i++){
+					arr_avg[i] += b_tmp->coordArr()[ind][i];
+					arr_init_avg[i] += partInitCoordsAttr->attValue(ind,i);
+				}			
+			}
+			
+			ORBIT_MPI_Allreduce(&total_macrosize,&total_macrosize_mpi,1,MPI_DOUBLE,MPI_SUM,b_tmp->getMPI_Comm_Local()->comm);
+			ORBIT_MPI_Allreduce(arr_avg,arr_avg_mpi,6,MPI_DOUBLE,MPI_SUM,b_tmp->getMPI_Comm_Local()->comm);
+			ORBIT_MPI_Allreduce(arr_init_avg,arr_init_avg_mpi,6,MPI_DOUBLE,MPI_SUM,b_tmp->getMPI_Comm_Local()->comm);
+			
+			total_macrosize = total_macrosize_mpi;
+			
+			//std::cout<<"debug total_macrosize="<<total_macrosize<<std::endl;
+			
+			for (int i = 0; i < 6; i++){
+				arr_avg_mpi[i] /= total_macrosize; 
+				arr_init_avg_mpi[i] /= total_macrosize;
+			}			
+			//--- now we have avg values for coordinates in and out
+			
+			for(int ind = 0; ind < n_parts; ind++){
+				double m_size = 1.0;
+				if(partMacroSizeAttr_tmp != NULL) m_size = partMacroSizeAttr_tmp->macrosize(ind);
+				for (int i = 0; i < 6; i++){
+					b_tmp->coordArr()[ind][i] -= m_size*arr_avg_mpi[i]; 
+					partInitCoordsAttr->attValue(ind,i) -= m_size*arr_init_avg_mpi[i];
+				}			
+			}	
+			
+			// A = (X^T * X)^-1 * (X^T *Y)  start
+			Matrix* XTXmtrx = new Matrix(6,6);
+			Matrix* XTYmtrx = new Matrix(6,6);
+			Matrix* Amtrx = new Matrix(6,6);
+			XTXmtrx->zero();
+			XTYmtrx->zero();
+			Amtrx->zero();
+			for (int i = 0; i < 6; i++){
+				for (int j = i; j < 6; j++){
+					for(int ind = 0; ind < n_parts; ind++){
+						double val = partInitCoordsAttr->attValue(ind,i)*partInitCoordsAttr->attValue(ind,j);
+						XTXmtrx->getArray()[i][j] += val;
+					}
+				}
+			}
+			for (int i = 0; i < 6; i++){
+				for (int j = 0; j < i; j++){
+					XTXmtrx->getArray()[i][j] = XTXmtrx->getArray()[j][i];
+				}
+			}
+			for (int i = 0; i < 6; i++){
+				for (int j = 0; j < 6; j++){
+					for(int ind = 0; ind < n_parts; ind++){
+						XTYmtrx->getArray()[i][j] += partInitCoordsAttr->attValue(ind,i)*b_tmp->coordArr()[ind][j];
+					}
+				}
+			}	
+			
+			//----- sum XTXmtrx and XTYmtrx over MPI
+			int count = 0;
+			for (int i = 0; i < 6; i++){
+				for (int j = 0; j < 6; j++){
+					mtrx_arr[count] = XTXmtrx->getArray()[i][j];
+					count++;
+				}
+			}
+			ORBIT_MPI_Allreduce(mtrx_arr,mtrx_arr_mpi,36,MPI_DOUBLE,MPI_SUM,b_tmp->getMPI_Comm_Local()->comm);
+			count = 0;
+			for (int i = 0; i < 6; i++){
+				for (int j = 0; j < 6; j++){
+					XTXmtrx->getArray()[i][j] = mtrx_arr_mpi[count];
+					count++;
+				}
+			}		
+			
+			count = 0;
+			for (int i = 0; i < 6; i++){
+				for (int j = 0; j < 6; j++){
+					mtrx_arr[count] = XTYmtrx->getArray()[i][j];
+					count++;
+				}
+			}
+			ORBIT_MPI_Allreduce(mtrx_arr,mtrx_arr_mpi,36,MPI_DOUBLE,MPI_SUM,b_tmp->getMPI_Comm_Local()->comm);
+			count = 0;
+			for (int i = 0; i < 6; i++){
+				for (int j = 0; j < 6; j++){
+					XTYmtrx->getArray()[i][j] = mtrx_arr_mpi[count];
+					count++;
+				}
+			}		
+			
+			// A = (X^T * X)^-1 * (X^T *Y)
+			XTXmtrx->copyTo(Amtrx);
+			MatrixOperations::invert(Amtrx);
+			
+			Amtrx->mult(XTYmtrx);
+			for (int i = 0; i < 6; i++){
+				A_mtr->getArray()[i][6] = 0.;
+				for (int j = 0; j < 6; j++){
+					A_mtr->getArray()[i][j] = Amtrx->getArray()[i][j];
+					A_mtr->getArray()[i][6] -= Amtrx->getArray()[i][j]*arr_init_avg_mpi[j];
+				}
+				A_mtr->getArray()[i][6] += arr_avg_mpi[i];
+			}
+			
+			A_mtr->getArray()[6][6] = 1.0;
+			
+			delete XTXmtrx;
+			delete XTYmtrx;
+			delete Amtrx;
+			OrbitUtils::BufferStore::getBufferStore()->setUnusedDoubleArr(buff_index0);
+			OrbitUtils::BufferStore::getBufferStore()->setUnusedDoubleArr(buff_index1);			
+			OrbitUtils::BufferStore::getBufferStore()->setUnusedDoubleArr(buff_index2);
+			OrbitUtils::BufferStore::getBufferStore()->setUnusedDoubleArr(buff_index3);			
+			OrbitUtils::BufferStore::getBufferStore()->setUnusedDoubleArr(buff_index4);
+			OrbitUtils::BufferStore::getBufferStore()->setUnusedDoubleArr(buff_index5);	
+		}	
+		
+		delete b_tmp;
+		
+		return n_parts_global;
+	}
+	
+	/** A function analyzes 6D coordinates and initial coords.
+	    Macrosize of macro-particles in the bunch will be 
+	    multiplied by wx*wy*wz where
+	    wx = exp(-(x^2+(alphax*x+betax*x')^2)/(2*(betax*emittancex))
+	    etc.
+	    Alpha, beta, emittance are the Twiss parameters for the corresponding 
+	    plane.
+	*/
+	void apply_twiss_weights_for_init_coords(Bunch* bunch,int appl_x,int appl_y,int appl_z){	
+		if(appl_x == 0 && appl_y == 0 && appl_z == 0) return;
+		
+		int n_parts =  bunch->getSize();
+		ParticleMacroSize* partMacroSizeAttr = NULL;
+		if(bunch->hasParticleAttributes("macrosize") == 0){
+			std::map<std::string,double> params_dict;
+			bunch->addParticleAttributes("macrosize",params_dict);
+			partMacroSizeAttr = (ParticleMacroSize*) bunch->getParticleAttributes("macrosize");
+			for(int ind = 0; ind < n_parts; ind++){
+				partMacroSizeAttr->macrosize(ind) = 1.;
+			}		
+		}
+
+		partMacroSizeAttr = (ParticleMacroSize*) bunch->getParticleAttributes("macrosize");
+		BunchTwissAnalysis* twissAnalysis = new BunchTwissAnalysis();	
+		
+		for(int iswap = 0; iswap < 2; ++iswap){
+	    if(iswap == 1){
+	    	swapInitCoordsAttrAndCoords(bunch);
+	    }
+
+			twissAnalysis->analyzeBunch(bunch);
+			
+			for(int ic = 0; ic < 3; ic++){
+				if(ic == 0 && appl_x == 0) continue;
+				if(ic == 1 && appl_y == 0) continue;
+				if(ic == 2 && appl_z == 0) continue;
+				double emitt = twissAnalysis->getEffectiveEmittance(ic);
+				double gamma = twissAnalysis->getEffectiveGamma(ic);
+				double alpha = twissAnalysis->getEffectiveAlpha(ic);
+				double beta = twissAnalysis->getEffectiveBeta(ic);		
+				double w = 0.;
+				double x=0.;
+				double xp = 0.;
+				int ic2 = ic*2;
+				int ic21 = ic*2+1;
+				for(int ind = 0; ind < n_parts; ind++){
+					x = bunch->coordArr()[ind][ic2];
+					xp = bunch->coordArr()[ind][ic21];
+					w = -(gamma*x*x+2*alpha*x*xp+beta*xp*xp)/(2*emitt);
+					if(fabs(w) > 36.)  w = 0.;
+					w = exp(w);
+					partMacroSizeAttr->macrosize(ind) *= w;
+				}
+			}
+		}
+		delete twissAnalysis;	
+		swapInitCoordsAttrAndCoords(bunch);
+	}
+}

--- a/src/utils/bunch/InitialCoordsAttrFunctions.hh
+++ b/src/utils/bunch/InitialCoordsAttrFunctions.hh
@@ -1,0 +1,80 @@
+//////////////////////////////// -*- C++ -*- //////////////////////////////
+//
+// FILE NAME
+//   InitialCoordsAttrFunctions.hh
+//
+// AUTHOR
+//    A. Shishlo
+//
+// CREATED
+//    03/27/2016
+//
+// DESCRIPTION
+//    A set of functions for bunches with the ParticleInitialCoordinates attribute
+//
+///////////////////////////////////////////////////////////////////////////
+
+#ifndef PARTICLES_INIT_COORDS_FUNCTIONS_H
+#define PARTICLES_INIT_COORDS_FUNCTIONS_H
+
+#include <cmath>
+
+//ORBIT bunch
+#include "Bunch.hh"
+
+#include "Matrix.hh"
+
+namespace OrbitUtils{
+	
+	/** 
+	  A function that will copy coordinates of the particles to 
+	  the 6D initial coordinates Attribute (ParticleInitialCoordinates).
+	 */
+	void copyCoordsToInitCoordsAttr(Bunch* bunch);
+	
+	/** 
+	  A function that will swap the initial coordinates Attribute 
+	  (ParticleInitialCoordinates) and the 6D coordinates of the particles.
+	  If the bunch does not have the ParticleInitialCoordinates particles attributes
+	  they will be created and full out with 0s, and then they will be swept.
+	 */
+	void swapInitCoordsAttrAndCoords(Bunch* bunch);
+	
+	/** 
+	  Calculates transport matrix A: x_out = A*x_in +b. A is a 7x7 matrix. 
+		The last column of A is the b vector.
+	  It returns 0 if unsuccessful or the size of the statistics otherwise.
+	  The function uses the initial coordinates attributes as x_in and the usual
+	  coordinates as x_out.
+	*/
+	int transport_mtrx_from_init_coords(Bunch* bunch, Matrix* A_mtr);
+	
+	/** A function analyzes two bunches assuming the vectors of coordinates 
+	    transformation x_out = A*x_in + b, where x_in the initial coordinates,
+			and x_out final. The results are matrix A (7x7) with the last column as a vector b.
+	    The function uses the initial coordinates attributes as x_in and the usual
+	    coordinates as x_out.
+			It returns 0 if unsuccessful or the size of the statistics otherwise.
+			For statistics it uses the weights according to Gaussian distribution with
+			Twiss parameters.
+	*/
+	int transport_mtrx_from_init_coords(Bunch* bunch, Matrix* A_mtr, int appl_twiss_x, int appl_twiss_y, int appl_twiss_z);	
+	
+	/** A function analyzes bunch with (ParticleInitialCoordinates) attributes 
+	    Macrosizes of macro-particles in the bunch will be 
+	    multiplied by the numbers wx0*wy0*wz0*wx1*wy1*wz1 where
+	    wx(In or Out) = exp(-(x^2+(alphax*x+betax*x')^2)/(2*(betax*emittancex))
+	    etc.
+	    Alpha, beta, emittance are the Twiss parameters for the corresponding 
+	    plane.
+	*/
+	void apply_twiss_weights_for_init_coords(Bunch* bunch,int appl_x,int appl_y,int appl_z);	
+	
+};
+///////////////////////////////////////////////////////////////////////////
+//
+// END OF FILE
+//
+///////////////////////////////////////////////////////////////////////////
+
+#endif

--- a/src/utils/bunch/ParticlesWithIdFunctions.cc
+++ b/src/utils/bunch/ParticlesWithIdFunctions.cc
@@ -10,7 +10,17 @@
 //    09/01/2015
 //
 // DESCRIPTION
-//    A set of functions for bunches with the ParticleIdNumber attribute
+//    A set of functions for bunches with the ParticleIdNumber attribute.
+//    At this moment there are two main functions:
+//    1. transport_mtrx(bunch_in, bunch_out, Matrix* A_mtr)
+//    2. transport_mtrx(bunch_in, bunch_out, Matrix* A_mtr, int appl_twiss_x, int appl_twiss_y, int appl_twiss_z)
+//    These functions will fill out the A_mtr that will be a transport matrix between
+//    bunches in and out. The correspondence between macro-particles in two bunches
+//    is defined by the Id of the macro-particles.
+//    Before using these functions it is recommended to remove particles far away from the center
+//    of the phase space by using functions from TwissFilteringFunctions.cc
+//    Function 1 assumes the equal weights for all macro-partiles, and 2nd uses weights according
+//    wx = exp(-(x^2+(alphax*x+betax*x')^2)/(2*(betax*emittancex)) etc.
 //
 ///////////////////////////////////////////////////////////////////////////
 
@@ -328,7 +338,7 @@ namespace OrbitUtils{
 	
 	/** A function analyzes two bunches assuming that they are already
 	    sorted and synchronized according to the macro-particles Id. 
-	    Coordinates of macro-particles in "in" and "out" bunches will be 
+	    Macrosize of macro-particles in "in" and "out" bunches will be 
 	    multiplied by the same numbers wx*wy*wz where
 	    wx = exp(-(x^2+(alphax*x+betax*x')^2)/(2*(betax*emittancex))
 	    etc.

--- a/src/utils/bunch/ParticlesWithIdFunctions.cc
+++ b/src/utils/bunch/ParticlesWithIdFunctions.cc
@@ -175,7 +175,7 @@ namespace OrbitUtils{
 		double total_macrosize = 1.0*n_parts;
 		
 		//apply Twiss Gaussian weights to microsize. It will add macrosize Attr. if it does not exist
-		apply_twiss_weghts(b_in_tmp, b_out_tmp,appl_twiss_x,appl_twiss_y,appl_twiss_z);
+		apply_twiss_weights(b_in_tmp, b_out_tmp,appl_twiss_x,appl_twiss_y,appl_twiss_z);
 		
 		partMacroSizeAttr_in_tmp = NULL;
 		if(b_in_tmp->hasParticleAttributes("macrosize") != 0){
@@ -345,7 +345,7 @@ namespace OrbitUtils{
 	    Alpha, beta, emittance are the Twiss parameters for the corresponding 
 	    plane.
 	*/
-	void apply_twiss_weghts(Bunch* bunch_in, Bunch* bunch_out,int appl_x,int appl_y,int appl_z){	
+	void apply_twiss_weights(Bunch* bunch_in, Bunch* bunch_out,int appl_x,int appl_y,int appl_z){	
 		if(appl_x == 0 && appl_y == 0 && appl_z == 0) return;
 		
 		int n_parts =  bunch_in->getSize();

--- a/src/utils/bunch/ParticlesWithIdFunctions.hh
+++ b/src/utils/bunch/ParticlesWithIdFunctions.hh
@@ -49,14 +49,14 @@ namespace OrbitUtils{
 	
 	/** A function analyzes two bunches assuming that they are already
 	    sorted and synchronized according to the macro-particles Id. 
-	    Coordinates of macro-particles in "in" and "out" bunches will be 
+	    Macrosizes of macro-particles in "in" and "out" bunches will be 
 	    multiplied by the same numbers wx*wy*wz where
 	    wx = exp(-(x^2+(alphax*x+betax*x')^2)/(2*(betax*emittancex))
 	    etc.
 	    Alpha, beta, emittance are the Twiss parameters for the corresponding 
 	    plane.
 	*/
-	void apply_twiss_weghts(Bunch* bunch_in, Bunch* bunch_out,int appl_x,int appl_y,int appl_z);	
+	void apply_twiss_weights(Bunch* bunch_in, Bunch* bunch_out,int appl_x,int appl_y,int appl_z);	
 	
 };
 ///////////////////////////////////////////////////////////////////////////

--- a/src/utils/bunch/wrap_bunch_utils_functions.cc
+++ b/src/utils/bunch/wrap_bunch_utils_functions.cc
@@ -8,6 +8,7 @@
 
 #include "ParticlesWithIdFunctions.hh"
 #include "TwissFilteringFunctions.hh"
+#include "InitialCoordsAttrFunctions.hh"
 
 using namespace OrbitUtils;
 
@@ -19,10 +20,10 @@ namespace wrap_utils_bunch_functions{
 extern "C" {
 #endif
 	//---------------------------------------------------------
-	//Python ParticlesWithIdFunctions functions definition
+	//Python Bunch Utils Functions definition
 	//---------------------------------------------------------
 	
-	static PyObject* part_wit_id_sort(PyObject* self, PyObject* args)
+	static PyObject* wrap_part_wit_id_sort(PyObject* self, PyObject* args)
 	{
 
 		PyObject *pyIn;
@@ -45,16 +46,16 @@ extern "C" {
 		PyObject *pyOut;
 		PyObject *pyM;
 		int info_x = 0, info_y = 0, info_z = 0;
-		if(!PyArg_ParseTuple(args,"OOO|iii:trasport_with_twiss_Mtrx",&pyIn,&pyOut,&pyM,&info_x,&info_y,&info_z)){
-			error("trasport_with_twiss_Mtrx(Bunch in,Bunch out,Matrix, info_x, info_y, info_z) - Bunches and Matrix are needed.");
+		if(!PyArg_ParseTuple(args,"OOO|iii:transport_with_twiss_Mtrx",&pyIn,&pyOut,&pyM,&info_x,&info_y,&info_z)){
+			error("transport_with_twiss_Mtrx(Bunch in,Bunch out,Matrix, info_x, info_y, info_z) - Bunches and Matrix are needed.");
 		}			
 		PyObject* pyBunchType = wrap_orbit_bunch::getBunchType("Bunch");
 		if((!PyObject_IsInstance(pyIn,pyBunchType)) || (!PyObject_IsInstance(pyOut,pyBunchType)) ){
-			error("trasport_with_twiss_Mtrx(Bunch in,Bunch out,Matrix, info_x, info_y, info_z) - 1st or 2nd input parameter is not Bunch");
+			error("transport_with_twiss_Mtrx(Bunch in,Bunch out,Matrix, info_x, info_y, info_z) - 1st or 2nd input parameter is not Bunch");
 		}	
 		PyObject* pyORBIT_Matrix_Type = wrap_orbit_utils::getOrbitUtilsType("Matrix");
 		if(!PyObject_IsInstance(pyM,pyORBIT_Matrix_Type)){
-			error("trasport_with_twiss_Mtrx(Bunch in,Bunch out,Matrix, info_x, info_y, info_z) - function needs a matrix.");
+			error("transport_with_twiss_Mtrx(Bunch in,Bunch out,Matrix, info_x, info_y, info_z) - function needs a matrix.");
 		}		
 		Bunch* bunch_in = (Bunch*) ((pyORBIT_Object*) pyIn)->cpp_obj;
 		Bunch* bunch_out = (Bunch*) ((pyORBIT_Object*) pyOut)->cpp_obj;
@@ -63,6 +64,63 @@ extern "C" {
 		int n_stat = transport_mtrx(bunch_in,bunch_out,mtrx,info_x,info_y,info_z);
     return Py_BuildValue("i", n_stat);	
 	}			
+	
+	static PyObject* wrap_copyCoordsToInitCoordsAttr(PyObject* self, PyObject* args)
+	{
+
+		PyObject *pyIn;
+		if(!PyArg_ParseTuple(args,"O:copyCoordsToInitCoordsAttr",&pyIn)){
+			error("copyCoordsToInitCoordsAttr(Bunch) - Bunch is needed.");
+		}			
+		PyObject* pyBunchType = wrap_orbit_bunch::getBunchType("Bunch");
+		if((!PyObject_IsInstance(pyIn,pyBunchType))){
+			error("copyCoordsToInitCoordsAttr(Bunch) - input parameter is not Bunch");
+		}		
+		Bunch* bunch = (Bunch*) ((pyORBIT_Object*) pyIn)->cpp_obj;
+		copyCoordsToInitCoordsAttr(bunch);
+    Py_INCREF(Py_None);
+    return Py_None;	
+	}		
+	
+	static PyObject* wrap_swapInitCoordsAttrAndCoords(PyObject* self, PyObject* args)
+	{
+
+		PyObject *pyIn;
+		if(!PyArg_ParseTuple(args,"O:swapInitCoordsAttrAndCoords",&pyIn)){
+			error("swapInitCoordsAttrAndCoords(Bunch) - Bunch is needed.");
+		}			
+		PyObject* pyBunchType = wrap_orbit_bunch::getBunchType("Bunch");
+		if((!PyObject_IsInstance(pyIn,pyBunchType))){
+			error("swapInitCoordsAttrAndCoords(Bunch) - input parameter is not Bunch");
+		}		
+		Bunch* bunch = (Bunch*) ((pyORBIT_Object*) pyIn)->cpp_obj;
+		swapInitCoordsAttrAndCoords(bunch);
+    Py_INCREF(Py_None);
+    return Py_None;	
+	}			
+
+	static PyObject* wrap_transport_mtrx_from_init_coords(PyObject* self, PyObject* args)
+	{
+		PyObject *pyIn;
+		PyObject *pyM;
+		int info_x = 0, info_y = 0, info_z = 0;
+		if(!PyArg_ParseTuple(args,"OO|iii:transport_with_twiss_Mtrx",&pyIn,&pyM,&info_x,&info_y,&info_z)){
+			error("transport_with_twiss_Mtrx_FromInitCoords(Bunch in,Bunch out,Matrix, info_x, info_y, info_z) - Bunches and Matrix are needed.");
+		}			
+		PyObject* pyBunchType = wrap_orbit_bunch::getBunchType("Bunch");
+		if((!PyObject_IsInstance(pyIn,pyBunchType))){
+			error("transport_with_twiss_Mtrx_FromInitCoords(Bunch in,Matrix, info_x, info_y, info_z) - 1st input parameter is not Bunch");
+		}	
+		PyObject* pyORBIT_Matrix_Type = wrap_orbit_utils::getOrbitUtilsType("Matrix");
+		if(!PyObject_IsInstance(pyM,pyORBIT_Matrix_Type)){
+			error("transport_with_twiss_Mtrx_FromInitCoords(Bunch in,Matrix, info_x, info_y, info_z) - function needs a matrix.");
+		}		
+		Bunch* bunch = (Bunch*) ((pyORBIT_Object*) pyIn)->cpp_obj;
+		Matrix* mtrx = (Matrix*) ((pyORBIT_Object*) pyM)->cpp_obj;
+		
+		int n_stat = transport_mtrx_from_init_coords(bunch,mtrx,info_x,info_y,info_z);
+    return Py_BuildValue("i", n_stat);	
+	}		
 	
 	static PyObject* wrap_bunch_twiss_filtering(PyObject* self, PyObject* args)
 	{
@@ -86,22 +144,25 @@ extern "C" {
 	// defenition of the memebers of the python bunch_utils_functions wrapper module for functions
 	// they will be vailable from python level
 	static PyMethodDef BunchUtilsFunctionMethods[] = { 		
-		{"bunchSortId",  part_wit_id_sort    , METH_VARARGS, "bunchSortId(bunch) - Sorting bunch according to the Id particles attributes."},
-		{"trasportMtrx", wrap_transport_mtrx , METH_VARARGS, "trasportMtrx(bunch in, bunch out, matrix) - calculates transport matrix."},
+		{"bunchSortId",  wrap_part_wit_id_sort    , METH_VARARGS, "bunchSortId(bunch) - Sorting bunch according to the Id particles attributes."},
+		{"transportMtrx", wrap_transport_mtrx , METH_VARARGS, "transportMtrx(bunch in, bunch out, matrix) - calculates transport matrix."},
+		{"copyCoordsToInitCoordsAttr",wrap_copyCoordsToInitCoordsAttr, METH_VARARGS,"copyCoordsToInitCoordsAttr(bunch) - copy coords to Init Coords Attr."},
+		{"swapInitCoordsAttrAndCoords",wrap_swapInitCoordsAttrAndCoords, METH_VARARGS,"swapInitCoordsAttrAndCoords(bunch) - swap coords to Init Coords Attr."},
+		{"transportMtrxFromInitCoords", wrap_transport_mtrx_from_init_coords , METH_VARARGS, "transportMtrx(bunch in, matrix) - calculates transport matrix."},
 		{"bunchTwissFiltering",  wrap_bunch_twiss_filtering, METH_VARARGS, "bunchTwissFiltering(bunch_in,bunch_bad, x_lim, y_lim, z_lim) - bunch Twiss filtering"},		
 		{NULL, NULL, 0, NULL}        /* Sentinel */
 	};
 
 	//--------------------------------------------------
-	//Initialization function of the pyParticlesWithIdFunctions module
+	//Initialization function of the Bunch utilities module
 	//It will be called from utils wrapper initialization
 	//--------------------------------------------------
 	
-  void initBunchUtilsFunctions(PyObject* module, const char* part_with_id_module_name){
+  void initBunchUtilsFunctions(PyObject* module, const char* bunch_utils_module_name){
     //create ==operations with bunches== module
-    PyObject* module_partId = Py_InitModule(part_with_id_module_name,BunchUtilsFunctionMethods);
-		PyModule_AddObject(module,part_with_id_module_name,module_partId);
-		Py_INCREF(module_partId);
+    PyObject* module_local = Py_InitModule(bunch_utils_module_name,BunchUtilsFunctionMethods);
+		PyModule_AddObject(module,bunch_utils_module_name,module_local);
+		Py_INCREF(module_local);
 	}
 
 #ifdef __cplusplus


### PR DESCRIPTION
The linac lattice factory for J-PARC accelerator was added. J-PARC has many accelerator sequences that can be combined in different orders, so the sequence control was removed. The Trace3D-type distributed quad field was added to describe the J-PARC linac quads. The  Initial Coords. Particles Attributes were added to calculate the acceptance and a transport matix. 