### PR TITLE
Fixes SEGFAULT on Mac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sync with package repository
 
 After syncing run:
 ```shell
-sudo port install fftw mpich
+sudo port install fftw-3 mpich
 ```
 Alternatively you can use [Homebrew](http://brew.sh). 
 This tends to build a lot of packages from sources (especially for the first time), which can take a long time.

--- a/conf/Darwin/make_root_config
+++ b/conf/Darwin/make_root_config
@@ -3,5 +3,5 @@
 ######################################################################
 
 CXX             =  ${MPI_CPP}
-CXXFLAGS       += -g -O3 -DUSE_MPI=1 -I /usr/local/include/
-LINKFLAGS      += -dynamic -L/usr/local/lib
+CXXFLAGS       += -g -O3 -DUSE_MPI=1 -I /usr/local/include/ -I /opt/local/include
+LINKFLAGS      += -dynamic -L/usr/local/lib -L/opt/local/lib

--- a/src/utils/wrap_numrecipes.cc
+++ b/src/utils/wrap_numrecipes.cc
@@ -92,6 +92,7 @@ extern "C" {
   void initNumrecipes(PyObject* module, const char* num_recipes_name){
     //create numrecipes module
     PyObject* module_nr = Py_InitModule(num_recipes_name,NumrecipesModuleMethods);
+		Py_INCREF(module_nr);
 		PyModule_AddObject(module, num_recipes_name, module_nr);
 	}
 


### PR DESCRIPTION
Seems to fix #14. Needs additional testing by others. This requires manual testing on Mac.
Do we need to add following check as well? 
```python
if (PyType_Ready(module_nr) < 0) return;
```
Also added **/opt/local** to Darwin makefile to support Macports' installation of fftw-3 package.