### PR TITLE
Remove /usr/local from compiler flags on Mac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ sudo yum install python-devel mpich mpich-devel zlib-devel fftw-devel
 ```
 
 ### Mac 
-There are different package managers available.
-
-[MacPorts](https://www.macports.org)  
+We recommend to use [MacPorts](https://www.macports.org).
+  
 Sync with package repository
 
 `sudo port -v selfupdate`
@@ -33,12 +32,19 @@ After syncing run:
 ```shell
 sudo port install fftw-3 mpich
 ```
+Select mpich to enable mpicc
+
+```shell
+sudo port select mpi mpich-mp-fortran
+```
+
 Alternatively you can use [Homebrew](http://brew.sh). 
 This tends to build a lot of packages from sources (especially for the first time), which can take a long time.
 ```shell
 brew update
 brew install fftw mpich
 ```
+You will need to modify *[conf/Darwin/make_root_config](conf/Darwin/make_root_config)* and include Homebrew specific directories in compiler flags.
 
 ### Building the whole environment from source
 If you don't want to use standard libraries supplied by your distribution, you can build the whole environment from scratch. It is also possible to do this without having a root account. The process is described in detail [here](BuildFromSource.md).

--- a/conf/Darwin/make_root_config
+++ b/conf/Darwin/make_root_config
@@ -3,5 +3,5 @@
 ######################################################################
 
 CXX             =  ${MPI_CPP}
-CXXFLAGS       += -g -O3 -DUSE_MPI=1 -I /usr/local/include/ -I /opt/local/include
-LINKFLAGS      += -dynamic -L/usr/local/lib -L/opt/local/lib
+CXXFLAGS       += -g -O3 -DUSE_MPI=1  -I /opt/local/include
+LINKFLAGS      += -dynamic  -L/opt/local/lib


### PR DESCRIPTION
Should help Intel compilers, see #18.
Also updated README adding instructions how to select MPI in macports.