### PR TITLE
Fixed tilted element

### DIFF
--- a/py/orbit/py_linac/lattice/LinacAccNodes.py
+++ b/py/orbit/py_linac/lattice/LinacAccNodes.py
@@ -137,7 +137,7 @@ class LinacNode(BaseLinacNode):
 		"""
 		Sets the tilt angle for the tilt operation.
 		"""
-		self.__params["tilt"] = angle
+		self.setParam("tilt", angle)
 		self.__tiltNodeIN.setTiltAngle(angle)
 		self.__tiltNodeOUT.setTiltAngle( (-1.0) * angle)
 

--- a/py/orbit/sns_linac/LinacAccNodes.py
+++ b/py/orbit/sns_linac/LinacAccNodes.py
@@ -87,7 +87,7 @@ class LinacNode(BaseLinacNode):
 		"""
 		Sets the tilt angle for the tilt operation.
 		"""
-		self.__params["tilt"] = angle
+		self.setParam("tilt", angle)
 		self.__tiltNodeIN.setTiltAngle(angle)
 		self.__tiltNodeOUT.setTiltAngle( (-1.0) * angle)
 

--- a/py/orbit/teapot/teapot.py
+++ b/py/orbit/teapot/teapot.py
@@ -524,7 +524,7 @@ class NodeTEAPOT(BaseTEAPOT):
 		"""
 		Sets the tilt angle for the tilt operation.
 		"""
-		self.__params["tilt"] = angle
+		self.setParam("tilt", angle)
 		self.__tiltNodeIN.setTiltAngle(angle)
 		self.__tiltNodeOUT.setTiltAngle( (-1.0) * angle)
 


### PR DESCRIPTION
```python
def setTiltAngle(self, angle = 0.):
```
was using  ```__params``` which is a left over from old code. 
Now parameters are controlled by **ParamsDictObject.py**