### PR TITLE
Macrosize calculation fix in BunchTwissAnalysis.cc

### DIFF
--- a/py/orbit/teapot/teapot.py
+++ b/py/orbit/teapot/teapot.py
@@ -684,7 +684,6 @@ class MonitorTEAPOT(NodeTEAPOT):
 		"""
 		The bunchtuneanalysis-teapot class implementation of the AccNodeBunchTracker class track(probe) method.
 		"""
-		length = self.getLength(self.getActivePartIndex())
 		bunch = paramsDict["bunch"]
 		self.twiss.analyzeBunch(bunch)
 		self.addParam("xAvg",self.twiss.getAverage(0))

--- a/src/orbit/BunchDiagnostics/BunchTwissAnalysis.cc
+++ b/src/orbit/BunchDiagnostics/BunchTwissAnalysis.cc
@@ -156,7 +156,7 @@ void BunchTwissAnalysis::computeBunchMoments(Bunch* bunch, int order, int disper
 	double m_size = 0.;
 	double xAvg = 0.;
 	double yAvg = 0.;
-	double total_macrosize = 0; //Total macrosize (can different than number of macroparticles if m_size is specified)
+	total_macrosize = 0; //Total macrosize (can different than number of macroparticles if m_size is specified)
 	int nParts = bunch->getSize();
 	double total_macrosize_MPI = 0.;
 	double** part_coord_arr = bunch->coordArr();
@@ -293,6 +293,9 @@ void BunchTwissAnalysis::computeBunchMoments(Bunch* bunch, int order, int disper
 		total_macrosize += nParts*m_size;
 		
 	}
+	
+	ORBIT_MPI_Allreduce(&total_macrosize,&total_macrosize_MPI,1,MPI_DOUBLE,MPI_SUM,bunch->getMPI_Comm_Local()->comm);
+	total_macrosize = total_macrosize_MPI;	
 	
 	//if( nMPIsize_ > 1){
 	double* buff_0 = (double *) malloc (sizeof(double)*(_order+1)*(_order+1));


### PR DESCRIPTION
The total_macrosize value was not summed over all CPUs during the momentXY calculations in the computeBunchMoments method. It is fixed. The the length value request was removed from MonitorTEAPOT method (track()), because the monitor has zero length by definition. 