### PR TITLE
Neighboring bunches + Some Backtraking 

### DIFF
--- a/py/orbit/lattice/AccNode.py
+++ b/py/orbit/lattice/AccNode.py
@@ -207,6 +207,17 @@ class AccNode(NamedObject, TypedObject, ParamsDictObject):
 			nodes += arr[1]
 		return nodes
 		
+	def getAllChildren(self):
+		"""
+		It returns the list of all children of this node.
+		The list includes children at entance, in body, and at exit.  
+		"""
+		nodes = []
+		nodes += self.getChildNodes(AccNode.ENTRANCE)
+		nodes += self.getBodyChildren()
+		nodes += self.getChildNodes(AccNode.EXIT)
+		return nodes
+		
 	def reverseOrder(self):
 		"""
 		This method is used for a lattice reversal and a bunch backtracking.
@@ -230,6 +241,7 @@ class AccNode(NamedObject, TypedObject, ParamsDictObject):
 			self.__childNodesArr[AccNode.BODY][iPart][AccNode.AFTER].reverse()
 			for node in self.__childNodesArr[AccNode.BODY][iPart][AccNode.BEFORE]: node.reverseOrderNodeSpecific()
 			for node in self.__childNodesArr[AccNode.BODY][iPart][AccNode.AFTER]: node.reverseOrderNodeSpecific()
+		self.reverseOrderNodeSpecific()
 		
 	def reverseOrderNodeSpecific(self):
 		"""

--- a/py/orbit/py_linac/lattice/LinacAccLatticeFunc.py
+++ b/py/orbit/py_linac/lattice/LinacAccLatticeFunc.py
@@ -29,8 +29,6 @@ def GetGlobalQuadGradient(accLattice,z):
 	Returns the quad field for certain position in the lattice that
 	has usual and overlapping quads.
 	"""
-	node_pos_dict = accLattice.getNodePositionsDict()
-	nodes = accLattice.getNodes()
 	G = 0.
 	(node,index,posBefore,posAfter) = accLattice.getNodeForPosition(z)
 	if(isinstance(node,Quad)):
@@ -50,8 +48,6 @@ def GetGlobalQuadGradientDerivative(accLattice,z):
 	Returns the quad field derivative for certain position in the lattice that
 	has usual and overlapping quads.
 	"""
-	node_pos_dict = accLattice.getNodePositionsDict()
-	nodes = accLattice.getNodes()
 	GP = 0.
 	(node,index,posBefore,posAfter) = accLattice.getNodeForPosition(z)
 	if(isinstance(node,Quad)):
@@ -73,8 +69,6 @@ def GetGlobalRF_AxisField(accLattice,z):
 	the BaseRF_Gap instance we will get 0, because it is 
 	an element with zero length.
 	"""	
-	node_pos_dict = accLattice.getNodePositionsDict()
-	nodes =accLattice.getNodes()
 	Ez = 0.
 	(node,index,posBefore,posAfter) = accLattice.getNodeForPosition(z)
 	if(isinstance(node,AxisField_and_Quad_RF_Gap) or isinstance(node,AxisFieldRF_Gap)):

--- a/py/orbit/py_linac/lattice/LinacAccLatticeLib.py
+++ b/py/orbit/py_linac/lattice/LinacAccLatticeLib.py
@@ -85,9 +85,14 @@ class LinacAccLattice(AccLattice):
 		apply the reverse recursively to the all children nodes.
 		"""
 		AccLattice.reverseOrder(self)
+		self.getSequences().reverse()
 		seqs = self.getSequences()
 		for seq in seqs:
-			seq.getNodes().reverse()
+			seq.reverseOrder()
+		#---- reverse order of RF gaps in the RF Cavities and change the first RF gap assignment
+		for rf_cavity in self.getRF_Cavities():
+			rf_cavity.reverseOrder()
+		#---- now initialization of the lattice
 		self.initialize()
 		#------ the positions of the nodes inside sequences will be defined by their positions 
 		#------ inside their order in the AccLattice. It is necessary for the reverse order
@@ -465,8 +470,28 @@ class RF_Cavity(NamedObject,ParamsDictObject):
 	def getRF_GapNodes(self):
 		""" Returns the array with rf gaps. """
 		return self.__rfGaps
+		
+	def reverseOrder(self):
+		"""
+		Reverse order of RF gaps in the cavity. 
+		The first gap should become the last and vice versa.
+		"""
+		n_gaps = len(self.__rfGaps)
+		if(n_gaps == 0): return 
+		self.__rfGaps.reverse()
+		self.__rfGaps[0].setAsFirstRFGap(True)
+		for ind in range(1,n_gaps):
+			self.__rfGaps[ind].setAsFirstRFGap(False)
+		for rfGap in self.__rfGaps:
+			gap_phase = rfGap.getGapPhase()
+			gap_phase = gap_phase + rfGap.getParam("mode")*math.pi
+			gap_phase = - gap_phase + math.pi
+			gap_phase = phaseNearTargetPhase(gap_phase,0.)
+			rfGap.setGapPhase(gap_phase)
+		self.setPhase(self.__rfGaps[0].getGapPhase())
+		self.setDesignSetUp(False)
 
-	
+
 class Sequence(NamedObject,ParamsDictObject):
 	"""
 	This is the class to keep refernces to AccNodes that constitute the accelerator sequence.
@@ -551,3 +576,11 @@ class Sequence(NamedObject,ParamsDictObject):
 		Sets the total length of the sequence [m].
 		"""		
 		return self.setParam("length",length)	
+		
+	def reverseOrder(self):
+		"""
+		Reverse order of nodes and RF cavities in sequence.
+		"""
+		self.__linacNodes.reverse()
+		self.__rfCavities.reverse()
+

--- a/py/orbit/py_linac/lattice/LinacAccLatticeLib.py
+++ b/py/orbit/py_linac/lattice/LinacAccLatticeLib.py
@@ -445,12 +445,10 @@ class RF_Cavity(NamedObject,ParamsDictObject):
 		""" Returns average phase for all RF gaps in the cavity """ 
 		avg_phase = 0.
 		phase = 0.
-		phase_arr = []
 		if(len(self.__rfGaps) > 0): 
 				phase = phaseNearTargetPhase(self.__rfGaps[0].getGapPhase(),0.)				
 		for rfGap in self.__rfGaps:
 			phase_new = phaseNearTargetPhase(rfGap.getGapPhase(),phase)
-			phase_arr.append(phase_new*180./math.pi)
 			avg_phase += phase_new
 			phase = phase_new
 		if(len(self.__rfGaps) > 0): avg_phase /= len(self.__rfGaps)

--- a/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
+++ b/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
@@ -44,8 +44,8 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		E0L parameter is in GeV. Phases are in radians.
 		"""
 		AbstractRF_Gap.__init__(self,axis_field_rf_gap.getName())
-		self.axis_field_rf_gap = axis_field_rf_gap
-		self.setType("axis_field_and_quad_rfgap")			
+		self.setType("GAP&Q")
+		self.axis_field_rf_gap = axis_field_rf_gap	
 		self.addParam("E0TL",self.axis_field_rf_gap.getParam("E0TL"))
 		self.addParam("mode",self.axis_field_rf_gap.getParam("mode"))
 		self.addParam("gap_phase",self.axis_field_rf_gap.getParam("gap_phase"))
@@ -73,6 +73,8 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		#---- quadrupole field sources
 		#----quads_fields_arr is an array of [quad, fieldFunc, z_center_of_field]
 		self.quads_fields_arr = []
+		#---- If it is true then the this tracking will be in the reversed lattice
+		self.reversed_lattice = False		
 		
 	def setLinacTracker(self, switch = True):
 		"""
@@ -110,13 +112,32 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		"""		
 		return self.axis_field_rf_gap.baserf_gap
 		
+	def reverseOrderNodeSpecific(self):
+		"""
+		This method is used for a lattice reversal and a bunch backtracking
+		This is a node type specific method. The implementation of the abstract
+		method of AccNode class from the top level lattice package. 
+		"""
+		self.reversed_lattice = not self.reversed_lattice
+		#---- Here the order of quads does not matter
+		for quad_ind in range(len(self.quads_fields_arr)):
+			[quad, fieldFunc, z_center_of_field] = self.quads_fields_arr[quad_ind]
+			self.quads_fields_arr[quad_ind][2] = - z_center_of_field
+		(self.z_min,self.z_max) = (-self.z_max,-self.z_min)  
+			
+	def isNodeInReversedLattice(self):
+		"""
+		Returns True if this node in the reversed lattice or False if it otherwise.
+		"""
+		return self.reversed_lattice		
+		
 	def addQuad(self, quad, fieldFunc, z_center_of_field):
 		"""
 		Adds the quad with the field function and the position.
 		The position of the quad is relative to the center of 
 		the parent rf gap node.
 		"""
-		self.quads_fields_arr.append((quad, fieldFunc, z_center_of_field))		
+		self.quads_fields_arr.append([quad, fieldFunc, z_center_of_field])		
 		
 	def getQuads(self):
 		"""
@@ -130,8 +151,11 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 	def getPosAndQuad_Arr(self):
 		"""
 		Return the array with pairs: the quad and the position of its center.
-		"""		
-		return self.quad_arr
+		"""
+		quad_arr = []
+		for [quad, fieldFunc, z_center_of_field] in self.quads_fields_arr:
+			quad_arr.append([quad,z_center_of_field])
+		return quad_arr
 
 	def getTotalField(self,z_from_center):
 		"""
@@ -210,6 +234,14 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		rfCavity = self.getRF_Cavity()
 		E0L = 1.0e+9*self.getParam("E0L")
 		rf_ampl = rfCavity.getAmp()
+		Ez = self.getEzFiledInternal(z,rfCavity,E0L,rf_ampl)
+		return Ez
+
+	def getEzFiledInternal(self,z,rfCavity,E0L,rf_ampl):
+		"""
+		Returns the Ez field on the axis of the RF gap in V/m. 
+		"""
+		if(self.reversed_lattice): z *= -1
 		Ez = E0L*rf_ampl*self.axis_field_rf_gap.axis_field_func.getY(z)	
 		return Ez
 
@@ -270,9 +302,9 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		zm = self.part_pos
 		z0 = zm + part_length/2
 		zp = z0 + part_length/2
-		Em = E0L*rf_ampl*self.axis_field_rf_gap.axis_field_func.getY(zm)
-		E0 = E0L*rf_ampl*self.axis_field_rf_gap.axis_field_func.getY(z0)
-		Ep = E0L*rf_ampl*self.axis_field_rf_gap.axis_field_func.getY(zp)			
+		Em = self.getEzFiledInternal(zm,rfCavity,E0L,rf_ampl)
+		E0 = self.getEzFiledInternal(z0,rfCavity,E0L,rf_ampl)
+		Ep = self.getEzFiledInternal(zp,rfCavity,E0L,rf_ampl)			
 		#------- track through a quad
 		G = self.getTotalField((zm+z0)/2)
 		GP = 0.
@@ -403,9 +435,9 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		zm = self.part_pos
 		z0 = zm + part_length/2
 		zp = z0 + part_length/2
-		Em = E0L*rf_ampl*self.axis_field_rf_gap.axis_field_func.getY(zm)
-		E0 = E0L*rf_ampl*self.axis_field_rf_gap.axis_field_func.getY(z0)
-		Ep = E0L*rf_ampl*self.axis_field_rf_gap.axis_field_func.getY(zp)			
+		Em = self.getEzFiledInternal(zm,rfCavity,E0L,rf_ampl)
+		E0 = self.getEzFiledInternal(z0,rfCavity,E0L,rf_ampl)
+		Ep = self.getEzFiledInternal(zp,rfCavity,E0L,rf_ampl)
 		#---- advance the particle position
 		self.tracking_module.drift(bunch,part_length/2)
 		self.part_pos += part_length/2	
@@ -471,7 +503,7 @@ class OverlappingQuadsNode(BaseLinacNode):
 		"""
 		Constructor. Creates the OverlappingQuadsNode instance.
 		"""
-		BaseLinacNode.__init__(self,name)
+		BaseLinacNode.__init__(self,name = "OVRLPQ")
 		self.setType("OVRLPQ")
 		self.setnParts(1)
 		#----quads_fields_arr is an array of [quad, fieldFunc, z_center_of_field]
@@ -484,6 +516,8 @@ class OverlappingQuadsNode(BaseLinacNode):
 		self.setLength(0.)
 		#---- If we going to use the longitudinal magnetic field component of quad
 		self.useLongField = False
+		#---- If it is true then the this tracking will be in the reversed lattice
+		self.reversed_lattice = False
 		
 	def setUseLongitudinalFieldOfQuad(self, use):
 		"""
@@ -497,12 +531,30 @@ class OverlappingQuadsNode(BaseLinacNode):
 		"""
 		return self.useLongField		
 		
+	def reverseOrderNodeSpecific(self):
+		"""
+		This method is used for a lattice reversal and a bunch backtracking
+		This is a node type specific method. The implementation of the abstract
+		method of AccNode class from the top level lattice package.  
+		"""
+		self.reversed_lattice = not self.reversed_lattice
+		#---- Here the order of quads does not matter
+		for quad_ind in range(len(self.quads_fields_arr)):
+			[quad, fieldFunc, z_center_of_field] = self.quads_fields_arr[quad_ind]
+			self.quads_fields_arr[quad_ind][2] = - z_center_of_field + self.getLength()
+			
+	def isNodeInReversedLattice(self):
+		"""
+		Returns True if this node in the reversed lattice or False if it otherwise.
+		"""
+		return self.reversed_lattice
+		
 	def addQuad(self, quad, fieldFunc, z_center_of_field):
 		"""
 		Adds the quad with the field function and the position.
 		The position of the quad is relative to the beginning of this OverlappingQuadsNode.
 		"""
-		self.quads_fields_arr.append((quad, fieldFunc, z_center_of_field))
+		self.quads_fields_arr.append([quad, fieldFunc, z_center_of_field])
 				
 	def setZ_Step(self,z_step):
 		"""

--- a/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
+++ b/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
@@ -287,7 +287,7 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		eKin_in = syncPart.kinEnergy()
 		momentum = syncPart.momentum()
 		E0L = 1.0e+9*self.getParam("E0L")
-		modePhase = self.getParam("mode")*math.pi
+		modePhase = self.axis_field_rf_gap.baserf_gap.getParam("mode")*math.pi
 		frequency = rfCavity.getFrequency()	
 		rf_ampl = rfCavity.getAmp()
 		arrival_time = syncPart.time()
@@ -408,7 +408,7 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		eKin_in = syncPart.kinEnergy()
 		#---- parameter E0L is in GeV, but cppGapModel = RfGapThreePointTTF() uses fields in V/m
 		E0L = 1.0e+9*self.getParam("E0L")
-		modePhase = self.getParam("mode")*math.pi
+		modePhase = self.axis_field_rf_gap.baserf_gap.getParam("mode")*math.pi
 		rfCavity = self.getRF_Cavity()
 		rf_ampl = rfCavity.getDesignAmp()
 		arrival_time = syncPart.time()

--- a/py/orbit/py_linac/lattice/LinacRfGapNodes.py
+++ b/py/orbit/py_linac/lattice/LinacRfGapNodes.py
@@ -596,7 +596,7 @@ class AxisFieldRF_Gap(AbstractRF_Gap):
 		syncPart = bunch.getSyncParticle()	
 		eKin_in = syncPart.kinEnergy()
 		E0L = 1.0e+9*self.getParam("E0L")
-		modePhase = self.getParam("mode")*math.pi
+		modePhase = self.baserf_gap.getParam("mode")*math.pi
 		frequency = rfCavity.getFrequency()	
 		rf_ampl = rfCavity.getAmp()
 		arrival_time = syncPart.time()
@@ -685,7 +685,7 @@ class AxisFieldRF_Gap(AbstractRF_Gap):
 		eKin_in = syncPart.kinEnergy()
 		#---- parameter E0L is in GeV, but cppGapModel = RfGapThreePointTTF() uses fields in V/m
 		E0L = 1.0e+9*self.getParam("E0L")
-		modePhase = self.getParam("mode")*math.pi
+		modePhase = self.baserf_gap.getParam("mode")*math.pi
 		rfCavity = self.getRF_Cavity()
 		rf_ampl = rfCavity.getDesignAmp()
 		arrival_time = syncPart.time()
@@ -783,7 +783,7 @@ class AxisFieldRF_Gap(AbstractRF_Gap):
 		#---- the design phase at the center of the RF gap 
 		#---- (this is from a thin gap approach)
 		frequency = rfCavity.getFrequency()
-		modePhase = self.getParam("mode")*math.pi
+		modePhase = self.baserf_gap.getParam("mode")*math.pi
 		phase_cavity = rfCavity.getPhase()
 		#---- parameter E0L is in GeV, but cppGapModel = RfGapThreePointTTF() uses fields in V/m
 		E0L_local = 1.0e+9*rfCavity.getAmp()*self.getParam("E0L")		

--- a/py/orbit/py_linac/lattice_modifications/quad_overlap_modifications_lib.py
+++ b/py/orbit/py_linac/lattice_modifications/quad_overlap_modifications_lib.py
@@ -231,8 +231,9 @@ def Replace_Quads_to_OverlappingQuads_Nodes(\
 			pos_end = node_pos_end
 			ovrlp_count = 0
 			for ind in range(len(zero_length_nodes)+1):
-				name = quads_arr[0].getName()+":group:"+str(ovrlp_count+1)+":OVRLPQ"
-				node = OverlappingQuadsNode(name)
+				node = OverlappingQuadsNode()
+				name = quads_arr[0].getName()+":group:"+str(ovrlp_count+1)+":"+node.getType()
+				node.setName(name)
 				if(ind == len(zero_length_nodes)):
 					pos_end = node_pos_end
 				else:

--- a/py/orbit/py_linac/lattice_modifications/rf_quad_overlap_modifications_lib.py
+++ b/py/orbit/py_linac/lattice_modifications/rf_quad_overlap_modifications_lib.py
@@ -200,8 +200,9 @@ def Replace_BaseRF_Gap_and_Quads_to_Overlapping_Nodes(\
 			pos_end = node_pos_end
 			ovrlp_count = 0
 			for ind in range(len(zero_length_nodes)+1):
-				name = rf_gap.getName()+":Before:"+str(ovrlp_count+1)+":OVRLPQ"
-				node = OverlappingQuadsNode(name)
+				node = OverlappingQuadsNode()
+				name = rf_gap.getName()+":Before:"+str(ovrlp_count+1)+":"+node.getType()
+				node.setName(name)
 				if(ind == len(zero_length_nodes)):
 					pos_end = node_pos_end
 				else:
@@ -244,8 +245,9 @@ def Replace_BaseRF_Gap_and_Quads_to_Overlapping_Nodes(\
 			pos_end = node_pos_end - accSeq_z_start
 			ovrlp_count = 0
 			for ind in range(len(zero_length_nodes)+1):
-				name = rf_gap.getName()+":After:"+str(ovrlp_count+1)+":OVRLPQ"
-				node = OverlappingQuadsNode(name)
+				node = OverlappingQuadsNode()
+				name = rf_gap.getName()+":After:"+str(ovrlp_count+1)+":"+node.getType()
+				node.setName(name)
 				if(ind == len(zero_length_nodes)):
 					pos_end = node_pos_end - accSeq_z_start
 				else:
@@ -292,8 +294,8 @@ def Replace_BaseRF_Gap_and_Quads_to_Overlapping_Nodes(\
 			#--------------------------------------------------------
 			ovrlp_count = 0
 			for ind in range(len(zero_length_nodes)+1):
-				name = rf_gap.getName()+":GAP&Q:"+str(ovrlp_count+1)
 				axisField_and_Quad_RF_Gap = AxisField_and_Quad_RF_Gap(axisFieldRF_Gap)
+				name = rf_gap.getName()+":"+axisField_and_Quad_RF_Gap.getType()+":"+str(ovrlp_count+1)
 				new_rf_gaps_arr.append(axisField_and_Quad_RF_Gap)
 				axisField_and_Quad_RF_Gap.setName(name)
 				if(ind == len(zero_length_nodes)):
@@ -338,8 +340,9 @@ def Replace_BaseRF_Gap_and_Quads_to_Overlapping_Nodes(\
 				pos_end = node_pos_end
 				ovrlp_count = 0
 				for ind in range(len(zero_length_nodes)+1):
-					name = rf_gap0.getName()+":After:"+str(ovrlp_count+1)+":OVRLPQ"
-					node = OverlappingQuadsNode(name)
+					node = OverlappingQuadsNode()
+					name = rf_gap0.getName()+":After:"+str(ovrlp_count+1)+":"+node.getType()
+					node.setName(name)
 					if(ind == len(zero_length_nodes)):
 						pos_end = node_pos_end
 					else:

--- a/py/orbit/utils/fitting/general_minimization/Solver.py
+++ b/py/orbit/utils/fitting/general_minimization/Solver.py
@@ -672,7 +672,7 @@ class Scoreboard:
 		"""
 		Adds a new best score listener.
 		"""		
-		self.bestScoreListener_arr.append(bestScoreListener)	
+		self.bestScoreListener_arr.append(bestScoreListener)
 			
 
 #====================================================================

--- a/src/spacecharge/Grid1D.cc
+++ b/src/spacecharge/Grid1D.cc
@@ -238,8 +238,8 @@ void Grid1D::binBunch(Bunch* bunch, int axis_ind)
 							<< "The axis_ind = "<<axis_ind<<" should be between 0 and 5"
 							<< std::endl << "number of bins = " << zSize_ << std::endl
 							<< "Stop." << std::endl;
+							ORBIT_MPI_Finalize();
 	}
-	ORBIT_MPI_Finalize();	
 	
   double m_size;
   bunch->compress();
@@ -287,8 +287,8 @@ void Grid1D::binBunchSmoothed(Bunch* bunch, int axis_ind)
 							<< "The axis_ind = "<<axis_ind<<" should be between 0 and 5"
 							<< std::endl << "number of bins = " << zSize_ << std::endl
 							<< "Stop." << std::endl;
-	}
-	ORBIT_MPI_Finalize();		
+							ORBIT_MPI_Finalize();	
+	}	
 	
   double m_size;
   bunch->compress();
@@ -332,6 +332,7 @@ void Grid1D::binBunchByParticle(Bunch* bunch, int axis_ind)
 							<< "The axis_ind = "<<axis_ind<<" should be between 0 and 5"
 							<< std::endl << "number of bins = " << zSize_ << std::endl
 							<< "Stop." << std::endl;
+							ORBIT_MPI_Finalize();	
 	}
 	
   bunch->compress();

--- a/src/spacecharge/Grid1D.cc
+++ b/src/spacecharge/Grid1D.cc
@@ -30,7 +30,7 @@ Grid1D::Grid1D(int zSize):CppPyWrapper(NULL)
   setZero();
 }
 
-/** Constructor with grid size and lattice length */
+/** Constructor with grid size and grid physical length */
 Grid1D::Grid1D(int zSize, double length):CppPyWrapper(NULL)
 {
 	zSize_ = zSize;
@@ -125,7 +125,7 @@ double Grid1D::getStepZ()
 /** Returns the grid point for index */
 double Grid1D::getGridZ(int index)
 {
-  return zMin_ + index * dz_;
+  return zMin_ + (index+0.5)*dz_;
 }
 
 
@@ -189,14 +189,14 @@ double Grid1D::getValue(double z)
   double arrval;
 
   getIndAndWZ(z, iZ0, iZp, WZ0, WZp);
+
   if(zSize_ > 1)
   {
     arrval = WZ0 * arr_[iZ0] + WZp * arr_[iZp];
+    return arrval;
   }
-  else if(zSize_ == 1)
-  {
-    arrval = arr_[iZ0];
-  }
+
+  arrval = arr_[0];
   return arrval;
 }
 
@@ -211,18 +211,7 @@ double Grid1D::getValueSmoothed(double z)
   getIndAndWZSmoothed(z, iZm,  iZ0,  iZp,
                          WZm,  WZ0,  WZp,
                         dWZm, dWZ0, dWZp);
-  if(zSize_ > 2)
-  {
-    arrval = WZm * arr_[iZm] + WZ0 * arr_[iZ0] + WZp * arr_[iZp];
-  }
-  else if(zSize_ == 2)
-  {
-    arrval = WZ0 * arr_[iZ0] + WZp * arr_[iZp];
-  }
-  else if(zSize_ == 1)
-  {
-    arrval = arr_[iZ0];
-  }
+  arrval = WZm * arr_[iZm] + WZ0 * arr_[iZ0] + WZp * arr_[iZp];
   return arrval;
 }
 
@@ -427,7 +416,7 @@ void Grid1D::binValue(double value, double z)
 
   double WZ0, WZp;
   int iZ0, iZp;
-  getIndAndWZ(z, iZ0, iZp, WZ0, WZp);
+  getBinIndAndWZ(z, iZ0, iZp, WZ0, WZp);
   if(zSize_ > 1)
   {
     arr_[iZ0] += WZ0 * value;
@@ -448,7 +437,7 @@ void Grid1D::binValueSmoothed(double value, double z)
   double  WZm,  WZ0,  WZp;
   double dWZm, dWZ0, dWZp;
   int iZm, iZ0, iZp;
-  getIndAndWZSmoothed(z, iZm,  iZ0,  iZp,
+  getBinIndAndWZSmoothed(z, iZm,  iZ0,  iZp,
                          WZm,  WZ0,  WZp,
                         dWZm, dWZ0, dWZp);
   if(zSize_ > 2)
@@ -476,7 +465,7 @@ void Grid1D::binMoment(double value, double z, double* Moment)
 
   double WZ0, WZp;
   int iZ0, iZp;
-  getIndAndWZ(z, iZ0, iZp, WZ0, WZp);
+  getBinIndAndWZ(z, iZ0, iZp, WZ0, WZp);
   if(zSize_ > 1)
   {
     Moment[iZ0] += WZ0 * value;
@@ -496,7 +485,7 @@ void Grid1D::binMomentSmoothed(double value, double z, double* Moment)
   double  WZm,  WZ0,  WZp;
   double dWZm, dWZ0, dWZp;
   int iZm, iZ0, iZp;
-  getIndAndWZSmoothed(z, iZm,  iZ0,  iZp,
+  getBinIndAndWZSmoothed(z, iZm,  iZ0,  iZp,
                          WZm,  WZ0,  WZp,
                         dWZm, dWZ0, dWZp);
   if(zSize_ > 2)
@@ -522,14 +511,15 @@ void Grid1D::calcGradient(double z, double& ez)
 {
   double WZ0, WZp;
   int iZ0, iZp;
+  
+  ez = 0.;
+  
+  if(z < zMin_ || z > zMax_ ) return;  
+  
   getIndAndWZ(z, iZ0, iZp, WZ0, WZp);
   if(zSize_ > 1)
   {
     ez = (arr_[iZp] - arr_[iZ0]) / dz_;
-  }
-  else if(zSize_ == 1)
-  {
-    ez = 0.;
   }
 }
 
@@ -543,6 +533,10 @@ void Grid1D::calcGradientSmoothed(double z, double& ez)
   getIndAndWZSmoothed(z, iZm,  iZ0,  iZp,
                          WZm,  WZ0,  WZp,
                         dWZm, dWZ0, dWZp);
+  ez = 0.;
+  
+  if(z < zMin_ || z > zMax_ ) return;
+  
   if(zSize_ > 2)
   {
     ez = dWZm * arr_[iZm] + dWZ0 * arr_[iZ0] + dWZp * arr_[iZp];
@@ -551,59 +545,12 @@ void Grid1D::calcGradientSmoothed(double z, double& ez)
   {
     ez = (arr_[iZp] - arr_[iZ0]) / dz_;
   }
-  else if(zSize_ == 1)
-  {
-    ez = 0.;
-  }
 }
 
-
-void Grid1D::getIndAndFracZ(double z, int& ind, double& frac)
-{
-  if(zSize_ > 1)
-  {
-    double zgloc = (z - zMin_) / dz_;
-    ind = int(zgloc);
-    frac = zgloc - double(ind);
-
-    // Keep indices in bounds
-    if(ind < 0) ind = zSize_ - 1;
-    if(ind > (zSize_ - 1)) ind =  0;
-  }
-  else
-  {
-    ind = 0;
-    frac = 1.0;
-  }
-}
-
-
-void Grid1D::getIndAndFracZSmoothed(double z, int& ind, double& frac)
-{
-  if(zSize_ > 2)
-  {
-    double zgloc = (z - zMin_) / dz_;
-    ind  = int(zgloc + 0.5);
-    frac = zgloc - double(ind);
-
-    // Keep indices in bounds
-    if(ind < 0) ind = zSize_ - 1;
-    if(ind > (zSize_ - 1)) ind =  0;
-  }
-  else if(zSize_ == 2)
-  {
-    ind = 0;
-    frac = (z - zMin_) / dz_;
-  }
-  else if(zSize_ == 1)
-  {
-    ind = 0;
-    frac = 1.0;
-  }
-}
-
-
-/** Returns the grid indices and interpolation coefficients for a given z.
+/** 
+    This is method for interpolation. The grid point responsibility is defined 
+    differently for binning and interpolation.
+    Returns the grid indices and interpolation coefficients for a given z.
     The indices bracket the point of interpolation:
     0 <= iZ0, iZp <= nBins - 1
     The coefficients WZ0 and WZp correspond to iZ0 and iZp */
@@ -611,16 +558,18 @@ void Grid1D::getIndAndWZ(double z,
                          int& iZ0   , int& iZp,
                          double& WZ0, double& WZp)
 {
+	double zFrac;
   if(zSize_ > 1)
   {
-    double zgloc = (z - zMin_) / dz_;
-    iZ0 = int(zgloc);
+  	iZ0 = int((z - zMin_)/dz_ - 0.5);
 
     // Keep indices in bounds
     if(iZ0 < 0) iZ0 = 0;
     if(iZ0 > (zSize_ - 2)) iZ0 = zSize_ - 2;
+    
+    zFrac = (z - this->getGridZ(iZ0))/dz_;
 
-    WZp = zgloc - double(iZ0);
+    WZp = zFrac;
     WZ0 = 1.0 - WZp;
 
     iZp = iZ0 + 1;
@@ -635,46 +584,89 @@ void Grid1D::getIndAndWZ(double z,
 }
 
 
-/** Returns the grid index and fractional position for particular z.
+/** 
+    This is method for binning. The grid point responsibility is defined 
+    differently for binning and interpolation.
+    Returns the grid indices and binning coefficients for a given z.
+    The indices bracket the point of interpolation:
+    0 <= iZ0, iZp <= nBins - 1
+    The coefficients WZ0 and WZp correspond to iZ0 and iZp 
+  */
+void Grid1D::getBinIndAndWZ(double z,
+                         int& iZ0   , int& iZp,
+                         double& WZ0, double& WZp)
+{
+	double zFrac;
+  if(zSize_ > 1)
+  {
+  	iZ0 = int((z - zMin_)/dz_);
+
+    // Keep indices in bounds
+    if(iZ0 < 0) iZ0 = 0;
+    if(iZ0 > (zSize_ - 2)) iZ0 = zSize_ - 2;
+    
+    zFrac = (z - this->getGridZ(iZ0))/dz_;
+
+    WZp = zFrac;
+    WZ0 = 1.0 - WZp;
+
+    iZp = iZ0 + 1;
+  }
+  else
+  {
+    iZ0 = 0;
+    iZp = 0;
+    WZ0  = 1.0;
+    WZp  = 0.0;
+  }
+}
+
+
+/** 
+    This is method for interpolation. The grid point responsibility is defined 
+    differently for binning and interpolation.
+    Returns the grid index and fractional position for particular z.
     The central index is the central point in smoothed three
     point interpolation:
     0 <= iZm, iZ0, iZp <= nBins - 1
     The coefficients WZm, WZ0, and WZp
-    correspond to iZm, iZ0, and iZp */
+    correspond to iZm, iZ0, and iZp 
+  */
 void Grid1D::getIndAndWZSmoothed(double z,
                                  int& iZm    , int& iZ0    , int& iZp    ,
                                  double& WZm , double& WZ0 ,  double& WZp,
                                  double& dWZm, double& dWZ0, double& dWZp)
 {
+	double frac;
   if(zSize_ > 2)
   {
-    double zgloc = 0.;
-    zgloc = (z - zMin_) / dz_;
-    iZ0 = int(zgloc + 0.5);
-
+  	iZ0 = int((z - zMin_)/dz_ - 0.5);
+  	
     // Keep indices in bounds
     if(iZ0 < 1) iZ0 = 1;
-    if(iZ0 > (zSize_ - 2)) iZ0 = zSize_ - 2;
+    if(iZ0 > (zSize_ - 2)) iZ0 = zSize_ - 2;  
+    
+    iZm = iZ0 - 1;
+    iZp = iZ0 + 1;
+    
+    frac = (z - this->getGridZ(iZ0))/dz_;
 
-    double frac = zgloc - double(iZ0);
     WZm  = 0.5 * (0.5 - frac) * (0.5 - frac);
     WZ0  = 0.75 - frac * frac;
     WZp  = 0.5 * (0.5 + frac) * (0.5 + frac);
     dWZm = (frac - 0.5) / dz_;
     dWZ0 = -2.0 * frac / dz_;
     dWZp = (frac + 0.5) / dz_;
-
-    iZm = iZ0 - 1;
-    iZp = iZ0 + 1;
   }
   else if(zSize_ == 2)
   {
+  	frac = (z - zMin_)/dz_ - 0.5;
+    iZm = 0;
     iZ0 = 0;
-    iZm = 1;
     iZp = 1;
     WZm = 0.0;
-    WZp = (z - zMin_) / dz_;
-    WZ0 = 1.0 - WZp;
+    WZ0 = 1.0 - frac;  
+    WZp = frac;
     dWZm =  0.0;
     dWZ0 = -1.0 / dz_;
     dWZp =  1.0 / dz_;
@@ -693,6 +685,73 @@ void Grid1D::getIndAndWZSmoothed(double z,
   }
 }
 
+
+
+/** 
+    This is method for binning. The grid point responsibility is defined 
+    differently for binning and interpolation.
+    Returns the grid index and fractional position for particular z.
+    The central index is the central point in smoothed three
+    point interpolation:
+    0 <= iZm, iZ0, iZp <= nBins - 1
+    The coefficients WZm, WZ0, and WZp
+    correspond to iZm, iZ0, and iZp 
+  */
+void Grid1D::getBinIndAndWZSmoothed(double z,
+                                 int& iZm    , int& iZ0    , int& iZp    ,
+                                 double& WZm , double& WZ0 ,  double& WZp,
+                                 double& dWZm, double& dWZ0, double& dWZp)
+{
+	double frac;
+  if(zSize_ > 2)
+  {
+  	iZ0 = int((z - zMin_)/dz_);
+    
+    if(iZ0 <= 0) iZ0 = 0;
+    if(iZ0 >= (zSize_ - 1)) iZ0 = zSize_ - 1;
+    
+    iZm = iZ0 - 1;
+    iZp = iZ0 + 1;
+    
+    //we assume periodic structure
+    if(iZm < 0) iZm = zSize_ - 1;
+    if(iZp >= zSize_) iZp = 0;    
+
+    frac = (z - this->getGridZ(iZ0))/dz_;
+    
+    WZm  = 0.5 * (0.5 - frac) * (0.5 - frac);
+    WZ0  = 0.75 - frac * frac;
+    WZp  = 0.5 * (0.5 + frac) * (0.5 + frac);
+    dWZm = (frac - 0.5) / dz_;
+    dWZ0 = -2.0 * frac / dz_;
+    dWZp = (frac + 0.5) / dz_;
+  }
+  else if(zSize_ == 2)
+  {
+  	frac = (z - zMin_)/dz_ - 0.5;
+    iZm = 0;
+    iZ0 = 0;
+    iZp = 1;
+    WZm = 0.0;
+    WZ0 = 1.0 - frac;  
+    WZp = frac;
+    dWZm =  0.0;
+    dWZ0 = -1.0 / dz_;
+    dWZp =  1.0 / dz_;
+  }
+  else if(zSize_ == 1)
+  {
+    iZm = 0;
+    iZ0 = 0;
+    iZp = 0;
+    WZm = 0.0;
+    WZ0 = 1.0;
+    WZp = 0.0;
+    dWZm = 0.0;
+    dWZ0 = 0.0;
+    dWZp = 0.0;
+  }
+}
 
 /** synchronizeMPI */
 void Grid1D::synchronizeMPI(pyORBIT_MPI_Comm* pyComm)

--- a/src/spacecharge/Grid1D.hh
+++ b/src/spacecharge/Grid1D.hh
@@ -142,35 +142,58 @@ private:
   /** Memory allocation and step calculation for dx_ and dy_ */
   void init();
 
-  /** Returns the grid index and fractional position for particular z.
-      The index is the lower point in interpolation:
-      0 <= ind <= nBins - 2
-      The fraction satisfies 0.0 <= frac <= 1.0 */
-  void getIndAndFracZ(double z, int& ind, double& frac);
-
-  /** Returns the grid index and fractional position for particular z.
-      The index is the central point in smoothed three point interpolation:
-      1 <= ind <= nBins - 2
-      The fraction satisfies -0.5 <= frac <= 0.5 */
-  void getIndAndFracZSmoothed(double z, int& ind, double& frac);
-
-  /** Returns the grid indices and interpolation coefficients for a given z.
+  /** 
+     This is method for interpolation. The grid point responsibility is defined 
+     differently for binning and interpolation.  
+      Returns the grid indices and interpolation coefficients for a given z.
       The indices bracket the point of interpolation:
       0 <= ind <= nBins - 1
-      The coefficients Wz0 and Wzp correspond to ind and indp */
+      The coefficients Wz0 and Wzp correspond to ind and indp 
+    */
   void getIndAndWZ(double z,
                    int& ind0  , int& indp,
                    double& Wz0, double& Wzp);
+  
+   /** 
+      This is method for binning. The grid point responsibility is defined 
+      differently for binning and interpolation.   
+      Returns the grid indices and interpolation coefficients for a given z.
+      The indices bracket the point of interpolation:
+      0 <= ind <= nBins - 1
+      The coefficients Wz0 and Wzp correspond to ind and indp 
+    */
+  void getBinIndAndWZ(double z,
+                   int& ind0  , int& indp,
+                   double& Wz0, double& Wzp); 
 
-  /** Returns the grid index and fractional position for particular z.
+  /** 
+      This is method for interpolation. The grid point responsibility is defined 
+      differently for binning and interpolation.   
+      Returns the grid index and fractional position for particular z.
       The central index is the central point in smoothed three
       point interpolation:
       0 <= ind <= nBins - 1
-      The fraction satisfies -0.5 <= frac <= 0.5 */
+      The fraction satisfies -0.5 <= frac <= 0.5 
+    */
   void getIndAndWZSmoothed(double z,
                            int& indm   , int& ind0   , int& indp   ,
                            double& Wzm , double& Wz0 , double& Wzp ,
                            double& dWzm, double& dWz0, double& dWzp);
+  
+  
+  /** 
+      This is method for binning. The grid point responsibility is defined 
+      differently for binning and interpolation.   
+      Returns the grid index and fractional position for particular z.
+      The central index is the central point in smoothed three
+      point interpolation:
+      0 <= ind <= nBins - 1
+      The fraction satisfies -0.5 <= frac <= 0.5 
+    */
+  void getBinIndAndWZSmoothed(double z,
+                           int& indm   , int& ind0   , int& indp   ,
+                           double& Wzm , double& Wz0 , double& Wzp ,
+                           double& dWzm, double& dWz0, double& dWzp);  
 
 protected:
 

--- a/src/spacecharge/Grid2D.cc
+++ b/src/spacecharge/Grid2D.cc
@@ -107,8 +107,17 @@ double Grid2D::getValue(double x, double y){
 	return value;
 }	
 
-/** Bins the Bunch into the 2D grid. If bunch has a macrosize particle attribute it will be used. */	
+/** Bins the Bunch into the 2D grid using X and Y coordinates. 
+    If bunch has a macrosize particle attribute it will be used. 
+  */	
 void Grid2D::binBunch(Bunch* bunch){
+	this->binBunch(bunch,0,2);
+}
+
+/** Bins the Bunch into the 2D grid using coordinate indexes ind0 and ind1. 
+    If bunch has a macrosize particle attribute it will be used. 
+  */	
+void Grid2D::binBunch(Bunch* bunch, int ind0, int ind1){
 	bunch->compress();
 	double** part_coord_arr = bunch->coordArr();
 	int has_msize = bunch->hasParticleAttributes("macrosize");
@@ -117,18 +126,16 @@ void Grid2D::binBunch(Bunch* bunch){
 		double m_size = 0.;
 		for(int i = 0, n = bunch->getSize(); i < n; i++){
 			m_size = macroSizeAttr->macrosize(i);
-			binValue(m_size,part_coord_arr[i][0],part_coord_arr[i][2]);
+			binValue(m_size,part_coord_arr[i][ind0],part_coord_arr[i][ind1]);
 		}	
 		return;
 	}
 	double m_size = bunch->getMacroSize();
 	int nParts = bunch->getSize();
 	for(int i = 0; i < nParts; i++){
-		binValue(m_size,part_coord_arr[i][0],part_coord_arr[i][2]);	
+		binValue(m_size,part_coord_arr[i][ind0],part_coord_arr[i][ind1]);	
 	}
 }
-
-
 
 /** Bins the value into the 2D grid */	
 void Grid2D::binValue(double value, double x, double y){
@@ -158,9 +165,14 @@ void Grid2D::binValue(double value, double x, double y){
   arr_[iX+1][iY+1] += Wxp * Wyp * value;             
 }
 
-/** Does a bilinear binning scheme on the bunch */
+/** Does a bilinear binning scheme on the bunch using X and Y coordinates */
 void Grid2D::binBunchBilinear(Bunch* bunch){
-	
+	this->binBunchBilinear(bunch,0,2);
+}
+
+/** Does a bilinear binning scheme on the bunch using coordinate indexes ind0 and ind1. 
+  */
+void Grid2D::binBunchBilinear(Bunch* bunch, int ind0, int ind1){
 	bunch->compress();
 	double** part_coord_arr = bunch->coordArr();
 	int nParts = bunch->getSize();
@@ -170,15 +182,14 @@ void Grid2D::binBunchBilinear(Bunch* bunch){
 			double m_size = 0.;
 			for(int i = 0, n = bunch->getSize(); i < n; i++){
 				m_size = macroSizeAttr->macrosize(i);
-				binValueBilinear(m_size,part_coord_arr[i][0],part_coord_arr[i][2]);
+				binValueBilinear(m_size,part_coord_arr[i][ind0],part_coord_arr[i][ind1]);
 			}
 			return;
 		}
 		double m_size = bunch->getMacroSize();
 		for(int i = 0; i < nParts; i++){
 			//cerr<<"i = "<<i;
-			binValueBilinear(m_size,part_coord_arr[i][0],part_coord_arr[i][2]);
-			
+			binValueBilinear(m_size,part_coord_arr[i][ind0],part_coord_arr[i][ind1]);
 		}
 }
 

--- a/src/spacecharge/Grid2D.hh
+++ b/src/spacecharge/Grid2D.hh
@@ -52,16 +52,24 @@ public:
 	/** Sets the value to the one point of the 2D grid  */	
 	void setValue(double value, int ix, int iy);
 
-  	/** Bins the Bunch into the 2D grid. If bunch has a macrosize 
-	    particle attribute it will be used. 
+  /** Bins the Bunch into the 2D grid using X and Y coordinates. 
+       If bunch has a macrosize particle attribute it will be used. 
 	*/	
 	void binBunch(Bunch* bunch);	
+	
+  /** Bins the Bunch into the 2D grid using coordinate indexes ind0 and ind1. 
+    If bunch has a macrosize particle attribute it will be used. 
+  */	
+  void binBunch(Bunch* bunch, int ind0, int ind1);	
 	
 	/** Bins the value into the 2D grid */	
 	void binValue(double value, double x, double y);	
 	
-	/** Does a bilinear binning scheme on the bunch */
+	/** Does a bilinear binning scheme on the bunch using X and Y coordinates */
 	void binBunchBilinear(Bunch* bunch);
+	
+  /** Does a bilinear binning scheme on the bunch using coordinate indexes ind0 and ind1. */
+  void binBunchBilinear(Bunch* bunch, int ind0, int ind1);
 	
 	/** Bilinear bin of the value into the 2D grid */
 	void binValueBilinear(double value, double x, double y);

--- a/src/spacecharge/Grid3D.cc
+++ b/src/spacecharge/Grid3D.cc
@@ -243,7 +243,7 @@ double Grid3D::getValueOnGrid(int ix, int iy, int iz){
 	return Arr3D[iz][ix][iy];
 }
 
-/** Bins the Bunch into the 2D grid. If bunch has a macrosize particle attribute it will be used. */	
+/** Bins the Bunch into the 3D grid. If bunch has a macrosize particle attribute it will be used. */	
 void Grid3D::binBunch(Bunch* bunch){
 	bunch->compress();
 	double** part_coord_arr = bunch->coordArr();
@@ -261,6 +261,36 @@ void Grid3D::binBunch(Bunch* bunch){
 	int nParts = bunch->getSize();
 	for(int i = 0; i < nParts; i++){
 		this->binValue(m_size,part_coord_arr[i][0],part_coord_arr[i][2],part_coord_arr[i][4]);	
+	}
+}
+
+/** 
+	Bins the Bunch into the 3D grid wrapping the longitudinal coordinates into
+	-Lambda/2 : +Lambda/2 interval. If bunch has a macrosize particle attribute 
+	it will be used. 
+*/	
+void Grid3D::binWrappedBunch(Bunch* bunch, double lambda){
+	bunch->compress();
+	double** part_coord_arr = bunch->coordArr();
+	int has_msize = bunch->hasParticleAttributes("macrosize");
+	double z_ini,z_wrapped;
+	if(has_msize > 0){
+		ParticleMacroSize* macroSizeAttr = (ParticleMacroSize*) bunch->getParticleAttributes("macrosize");
+		double m_size = 0.;
+		for(int i = 0, n = bunch->getSize(); i < n; i++){
+			m_size = macroSizeAttr->macrosize(i);
+			z_ini = part_coord_arr[i][4];
+			z_wrapped = remainder(z_ini,lambda);
+			this->binValue(m_size,part_coord_arr[i][0],part_coord_arr[i][2],z_wrapped);
+		}	
+		return;
+	}
+	double m_size = bunch->getMacroSize();
+	int nParts = bunch->getSize();
+	for(int i = 0; i < nParts; i++){
+		z_ini = part_coord_arr[i][4];
+		z_wrapped = remainder(z_ini,lambda);		
+		this->binValue(m_size,part_coord_arr[i][0],part_coord_arr[i][2],z_wrapped);	
 	}
 }
 

--- a/src/spacecharge/Grid3D.hh
+++ b/src/spacecharge/Grid3D.hh
@@ -114,21 +114,32 @@ public:
   /** define all elements as 0.0 */
   void setZero();
 
-  //multiply all elements of Grid3D by constant coefficient
+  /** multiply all elements of Grid3D by constant coefficient */
   void multiply(double coeff);
+  
+	/**
+		If it is equal 0 we do not have longitudinal wrapping.
+	*/
+	void setLongWrapping(int isWrapped);
+	
+	/**
+		If it is equal 0 we do not have longitudinal wrapping.
+	*/
+	int getLongWrapping(); 
 	
   /** Bins the Bunch into the 2D grid. If bunch has a 
-	    macrosize particle attribute it will be used. */	
+	    macrosize particle attribute it will be used. 
+	  */	
 	void binBunch(Bunch* bunch);
 	
-	/** 
-	Bins the Bunch into the 3D grid wrapping the longitudinal coordinates into
-	-Lambda/2 : +Lambda/2 interval. If bunch has a macrosize particle attribute 
-	it will be used. 
-	*/	
-	void binWrappedBunch(Bunch* bunch, double lambda);
+  /** Bins the Bunch into the 2D grid. If bunch has a 
+	    macrosize particle attribute it will be used.
+	    The coordinates of the particles will be wrapped 
+	    longitudinally with period of lambda.
+  */	
+	void binBunch(Bunch* bunch, double lambda);	
 	
-	/** Bins the value onto grid */
+  /** Bins the value onto grid */
   void binValue(double macroSize, double x, double y, double z);
 	
   /** Calculates gradient of Arr3D. gradX = gradient_x(Arr3D), and so on */
@@ -194,6 +205,10 @@ protected:
   int nZ_,nX_,nY_;
   double xMin_,xMax_,yMin_,yMax_,zMin_,zMax_;
   double dx_, dy_, dz_;
+  
+  //it is equal 0 we do not have longitudinal wrapping
+  //if it is 1 we have wrapping. By default it is 0. 
+  int longWrapping;
 
 };
 #endif

--- a/src/spacecharge/Grid3D.hh
+++ b/src/spacecharge/Grid3D.hh
@@ -121,6 +121,13 @@ public:
 	    macrosize particle attribute it will be used. */	
 	void binBunch(Bunch* bunch);
 	
+	/** 
+	Bins the Bunch into the 3D grid wrapping the longitudinal coordinates into
+	-Lambda/2 : +Lambda/2 interval. If bunch has a macrosize particle attribute 
+	it will be used. 
+	*/	
+	void binWrappedBunch(Bunch* bunch, double lambda);
+	
 	/** Bins the value onto grid */
   void binValue(double macroSize, double x, double y, double z);
 	

--- a/src/spacecharge/PoissonSolver3D.cc
+++ b/src/spacecharge/PoissonSolver3D.cc
@@ -18,7 +18,14 @@ PoissonSolver3D::PoissonSolver3D(int xSize, int ySize, int zSize): CppPyWrapper(
 	zMax_ = +1.0;
 	dx_ = (xMax_ - xMin_)/(xSize_ -1);
 	dy_ = (yMax_ - yMin_)/(ySize_ -1);	
-	dz_ = (zMax_ - zMin_)/(zSize_ -1);	
+	
+	/** 
+		Sets the limits for the z-grid. The z-grid is different
+		from x and y. We redefined it to allow the periodicity
+		along the longitudinal coordinate in the beam.
+	*/	
+	
+	dz_ = (zMax_ - zMin_)/zSize_;	
 }
 
 // Constructor
@@ -38,7 +45,14 @@ PoissonSolver3D::PoissonSolver3D(int xSize, int ySize, int zSize,
 	zMax_ = zMax;	
 	dx_ = (xMax_ - xMin_)/(xSize_ -1);
 	dy_ = (yMax_ - yMin_)/(ySize_ -1);	
-	dz_ = (zMax_ - zMin_)/(zSize_ -1);		
+	
+	/** 
+		Sets the limits for the z-grid. The z-grid is different
+		from x and y. We redefined it to allow the periodicity
+		along the longitudinal coordinate in the beam.
+	*/	
+	
+	dz_ = (zMax_ - zMin_)/zSize_;		
 }
 
 // Destructor

--- a/src/spacecharge/PoissonSolverFFT3D.cc
+++ b/src/spacecharge/PoissonSolverFFT3D.cc
@@ -151,6 +151,11 @@ void PoissonSolverFFT3D::setGridXYZ(double xMin, double xMax, double yMin, doubl
 	_defineGreenF();
 }
 
+/** Updates the Green function FFT */
+void PoissonSolverFFT3D::updateGreenFunction(){
+	this->_defineGreenF();
+}
+
 // Defines the FFT of the Green Function: field = Q/r^2, potential = Q/r
 void PoissonSolverFFT3D::_defineGreenF()
 {
@@ -255,7 +260,7 @@ void PoissonSolverFFT3D::findPotential(Grid3D* rhoGrid,Grid3D*  phiGrid)
 		int rank = 0;
 		ORBIT_MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 		if(rank == 0){
-			std::cerr << "PoissonSolverFFT3D:" 
+			std::cerr << "PoissonSolverFFT3D:findPotential" 
 			<< "The grid sizes or shape are different "<< std::endl 
 								<< "number x bins ="<< xSize_ << std::endl
 								<< "number y bins ="<< ySize_ << std::endl
@@ -288,14 +293,7 @@ void PoissonSolverFFT3D::findPotential(Grid3D* rhoGrid,Grid3D*  phiGrid)
 
 	double*** rhosc = rhoGrid->getArr3D();
 	double*** phisc = phiGrid->getArr3D();
-	
-	//if nBunches_ > 0 the scale_coeff will be always 1.0
-	if(nBunches_ > 0){
-		setGridXYZ(rhoGrid->getMinX(), rhoGrid->getMaxX(),
-			         rhoGrid->getMinY(), rhoGrid->getMaxY(),
-			         rhoGrid->getMinZ(), rhoGrid->getMaxZ());
-	}
-	
+
 	double scale_coeff = dx_/rhoGrid->getStepX();
 		
   int i, j, k, index;

--- a/src/spacecharge/PoissonSolverFFT3D.hh
+++ b/src/spacecharge/PoissonSolverFFT3D.hh
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <string>
+#include <cfloat>
 
 //pyORBIT utils
 #include "CppPyWrapper.hh"
@@ -43,6 +44,18 @@ class PoissonSolverFFT3D: public PoissonSolver3D
 		/** Destructor */
 		virtual ~PoissonSolverFFT3D();
 		
+		/** Set number of bunches from both sides for space charge calculations */
+		void setNumberOfExternalBunches(int nBunches);
+
+		/** Set distance between external bunches - period */
+		void setSpacingOfExternalBunches(double lambda);	
+		
+		/** Get number of bunches from both sides for space charge calculations */
+		int getNumberOfExternalBunches();
+		
+		/** Get distance between bunches */
+		double getSpacingOfExternalBunches();
+
 	  void setGridX(double xMin, double xMax); 	
 	  void setGridY(double yMin, double yMax);
 	  void setGridZ(double zMin, double zMax);
@@ -85,6 +98,14 @@ class PoissonSolverFFT3D: public PoissonSolver3D
 			fftw_plan planForward_greenF_;
 			fftw_plan planForward_;
 			fftw_plan planBackward_;
+			
+			//Number of bunches from both sides that should be taken into account.
+			//It defines the how many components we will add to Green function.
+			//This number will be an even number.
+			int nBunches_;
+			
+			//The distance between centers of the neighboring bunches
+			double lambda_;
 };
 //end of SC_POISSON_SOLVER_FFT_3D_H ifdef
 #endif

--- a/src/spacecharge/PoissonSolverFFT3D.hh
+++ b/src/spacecharge/PoissonSolverFFT3D.hh
@@ -61,6 +61,9 @@ class PoissonSolverFFT3D: public PoissonSolver3D
 	  void setGridZ(double zMin, double zMax);
 		void setGridXYZ(double xMin, double xMax, double yMin, double yMax, double zMin, double zMax);
 		
+		/** Updates the Green function FFT */
+		void updateGreenFunction();
+		
 		/** Solves the Poisson problem for an external charge distribution and
 		puts results into an external potential grid
 		*/
@@ -78,34 +81,34 @@ class PoissonSolverFFT3D: public PoissonSolver3D
 		//define green functions table
 		void _defineGreenF();
 		
-		protected:
-			
-			//Twice extended grid size to use convolution method
-			int xSize2_;
-			int ySize2_; 
-			int zSize2_; 
-			
-			//Green function 
-			double*** greensF_;
-			
-			//FFT arrays
-			double* in_;
-			double* in_res_;
-			fftw_complex* out_green_;
-			fftw_complex* out_;
-			fftw_complex* out_res_;
-			
-			fftw_plan planForward_greenF_;
-			fftw_plan planForward_;
-			fftw_plan planBackward_;
-			
-			//Number of bunches from both sides that should be taken into account.
-			//It defines the how many components we will add to Green function.
-			//This number will be an even number.
-			int nBunches_;
-			
-			//The distance between centers of the neighboring bunches
-			double lambda_;
+	protected:
+		
+		//Twice extended grid size to use convolution method
+		int xSize2_;
+		int ySize2_; 
+		int zSize2_; 
+		
+		//Green function 
+		double*** greensF_;
+		
+		//FFT arrays
+		double* in_;
+		double* in_res_;
+		fftw_complex* out_green_;
+		fftw_complex* out_;
+		fftw_complex* out_res_;
+		
+		fftw_plan planForward_greenF_;
+		fftw_plan planForward_;
+		fftw_plan planBackward_;
+		
+		//Number of bunches from both sides that should be taken into account.
+		//It defines the how many components we will add to Green function.
+		//This number will be an even number.
+		int nBunches_;
+		
+		//The distance between centers of the neighboring bunches
+		double lambda_;
 };
 //end of SC_POISSON_SOLVER_FFT_3D_H ifdef
 #endif

--- a/src/spacecharge/SpaceChargeCalc3D.cc
+++ b/src/spacecharge/SpaceChargeCalc3D.cc
@@ -244,11 +244,6 @@ void SpaceChargeCalc3D::bunchAnalysis(Bunch* bunch){
 	phiGrid->setGridZ(zMin,zMax);		
 }
 
-
-
-
-
-
 void SpaceChargeCalc3D::wrappedBunchAnalysis(Bunch* bunch){
 	
 	double width, center;
@@ -269,6 +264,9 @@ void SpaceChargeCalc3D::wrappedBunchAnalysis(Bunch* bunch){
 	
 	//distance between bunches in the laboratory system
 	double lambda = OrbitConst::c*beta/frequency_;
+	
+	//distance between bunches in the center of mass of the bunch
+	double lambda_cm = OrbitConst::c*beta*gamma/frequency_;	
 	
 	if(fabs(zMax) > lambda/2 || fabs(zMin) > lambda/2){
 		// extension should not change the results at all. It just changes the grid size.
@@ -314,17 +312,15 @@ void SpaceChargeCalc3D::wrappedBunchAnalysis(Bunch* bunch){
 	zMin = center - width;
 	zMax = center + width;		
 	rhoGrid->setGridZ(zMin,zMax);	
-	phiGrid->setGridZ(zMin,zMax);		
+	phiGrid->setGridZ(zMin,zMax);
+	
+	//now we set the sizes of the Poisson Solver grids and 
+	//calculate Green function FFT inside it
+	poissonSolver->setSpacingOfExternalBunches(lambda_cm);
+	poissonSolver->setGridXYZ(rhoGrid->getMinX(), rhoGrid->getMaxX(),
+			                      rhoGrid->getMinY(), rhoGrid->getMaxY(),
+			                      rhoGrid->getMinZ(), rhoGrid->getMaxZ());
 }
-
-
-
-
-
-
-
-
-
 
 /** Sets the ratio limit for the shape change and Green Function recalculations. */
 void SpaceChargeCalc3D::setRatioLimit(double ratio_limit_in)

--- a/src/spacecharge/SpaceChargeCalc3D.hh
+++ b/src/spacecharge/SpaceChargeCalc3D.hh
@@ -53,10 +53,25 @@ public:
 	/** Returns the ratio limit for the shape change and Green Function recalculations. */
 	double getRatioLimit();
 	
+	/** Set number of bunches from both sides for space charge calculations */
+	void setNumberOfExternalBunches(int nBunches);
+
+	/** Set frequency of the arrivals of the bunches */
+	void setFrequencyOfBunches(double frequency);
+
+	/** Get number of bunches from both sides for space charge calculations */
+	int getNumberOfExternalBunches();
+	
+	/** Get frequency of the arrivals of the bunches */
+	double getFrequencyOfBunches();
+	
 private:
 	
-	/** Analyses the bunch and does bining. */
- void bunchAnalysis(Bunch* bunch);	
+	/** Analyses the bunch and does binning. */
+	void bunchAnalysis(Bunch* bunch);
+ 
+	/** Analyses the bunch and does binning in the case of accounting for neighboring bunches */
+ 	void wrappedBunchAnalysis(Bunch* bunch);
 	
 protected:
 	PoissonSolverFFT3D* poissonSolver;
@@ -71,6 +86,14 @@ protected:
 	//If the shape (x to y and x to z ratios) of 3D region changes more than this
 	//limit then we have to change shape and recalculate Green Functions in the Poisson solver	
 	double ratio_limit;
+	
+	//Number of bunches from both sides that should be taken into account.
+	//It defines the how many components we will add to Green function.
+	//This number will be an even number.
+	int nBunches_;
+	
+	//The frequency of the bunch arrivals in Hz. It defines by the RFQ frequency.
+	double frequency_;
 };
 //end of SC_SPACECHARGE_CALC_3D_H
 #endif

--- a/src/spacecharge/wrap_grid1D.cc
+++ b/src/spacecharge/wrap_grid1D.cc
@@ -45,19 +45,19 @@ static int Grid1D_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds)
 {
   int nVars = PyTuple_Size(args);
   int binZ;
-  double length;
+  double length = 1.0;
   double zMin = -1.0, zMax = +1.0;
   if (nVars == 2){
 	  if(!PyArg_ParseTuple(args,"i|d:__init__", &binZ, &length))
 	  {
-		  ORBIT_MPI_Finalize("PyGrid1D - Grid1D(0Z, length]) - constructor needs parameters.");
+		  ORBIT_MPI_Finalize("PyGrid1D - Grid1D(nZ, length]) - constructor needs parameters.");
 	  }
 	  self->cpp_obj = new Grid1D(binZ, length);
   }
   if (nVars ==1 || nVars == 3 ){
-	if(!PyArg_ParseTuple(args,"i|ddd:__init__", &binZ, &zMin, &zMax))
+	if(!PyArg_ParseTuple(args,"i|dd:__init__", &binZ, &zMin, &zMax))
 	{
-		ORBIT_MPI_Finalize("PyGrid1D - Grid1D(0Z[, zMin, zMax]) - constructor needs parameters.");
+		ORBIT_MPI_Finalize("PyGrid1D - Grid1D(nZ[, zMin, zMax]) - constructor needs parameters.");
 	}
 	self->cpp_obj = new Grid1D(binZ, zMin, zMax);
   }

--- a/src/spacecharge/wrap_grid2D.cc
+++ b/src/spacecharge/wrap_grid2D.cc
@@ -246,38 +246,50 @@ extern "C" {
 		return Py_BuildValue("i",cpp_Grid2D->isInside(x,y));
 	}		
 	
-	//binBunch(Bunch* bunch)
+	//binBunch(Bunch* bunch, [ind0,ind1]), by default ind0 = 0, ind1 = 2 (XY) plane
   static PyObject* Grid2D_binBunch(PyObject *self, PyObject *args){
     pyORBIT_Object* pyGrid2D = (pyORBIT_Object*) self;
 		Grid2D* cpp_Grid2D = (Grid2D*) pyGrid2D->cpp_obj;
 		PyObject* pyBunch;
-		if(!PyArg_ParseTuple(args,"O:binBunch",&pyBunch)){
-			ORBIT_MPI_Finalize("PyGrid2D - binBunch(Bunch* bunch) - parameter are needed.");
+		int ind0 = -1;
+		int ind1 = -1;
+		if(!PyArg_ParseTuple(args,"O|ii:binBunch",&pyBunch,&ind0,&ind1)){
+			ORBIT_MPI_Finalize("PyGrid2D - binBunch(Bunch* bunch, [ind0,ind1]) - parameter are needed.");
 		}
 		PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
 		if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
-			ORBIT_MPI_Finalize("PyGrid2D - binBunch(Bunch* bunch) - method needs a Bunch.");
+			ORBIT_MPI_Finalize("PyGrid2D - binBunch(Bunch* bunch, [ind0,ind1]) - method needs a Bunch.");
 		}
 		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
-		cpp_Grid2D->binBunch(cpp_bunch);
+		if(ind0 < 0 || ind1 < 0 || ind0 > 5 || ind1 > 5){
+		  cpp_Grid2D->binBunch(cpp_bunch);
+		} else {
+			cpp_Grid2D->binBunch(cpp_bunch,ind0,ind1);
+		}
 		Py_INCREF(Py_None);
     return Py_None;	
 	}		
 		
-	//binBunchBilinear(Bunch* bunch)
+	//binBunchBilinear(Bunch* bunch, [ind0,ind1]), by default ind0 = 0, ind1 = 2 (XY) plane
   static PyObject* Grid2D_binBunchBilinear(PyObject *self, PyObject *args){
     pyORBIT_Object* pyGrid2D = (pyORBIT_Object*) self;
 		Grid2D* cpp_Grid2D = (Grid2D*) pyGrid2D->cpp_obj;
 		PyObject* pyBunch;
-		if(!PyArg_ParseTuple(args,"O:binBunchBilinear",&pyBunch)){
-			ORBIT_MPI_Finalize("PyGrid2D - binBunchBilinear(Bunch* bunch) - parameter are needed.");
+		int ind0 = -1;
+		int ind1 = -1;
+		if(!PyArg_ParseTuple(args,"O|ii:binBunchBilinear",&pyBunch,&ind0,&ind1)){
+			ORBIT_MPI_Finalize("PyGrid2D - binBunchBilinear(Bunch* bunch, [ind0,ind1]) - parameter are needed.");
 		}
 		PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
 		if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
-			ORBIT_MPI_Finalize("PyGrid2D - binBunchBilinear(Bunch* bunch) - method needs a Bunch.");
+			ORBIT_MPI_Finalize("PyGrid2D - binBunchBilinear(Bunch* bunch, [ind0,ind1]) - method needs a Bunch.");
 		}
 		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
-		cpp_Grid2D->binBunchBilinear(cpp_bunch);
+		if(ind0 < 0 || ind1 < 0 || ind0 > 5 || ind1 > 5){
+		  cpp_Grid2D->binBunchBilinear(cpp_bunch);
+		} else {
+			cpp_Grid2D->binBunchBilinear(cpp_bunch,ind0,ind1);
+		}
 		Py_INCREF(Py_None);
     return Py_None;	
 	}	
@@ -368,8 +380,8 @@ extern "C" {
 		{ "isInside",             Grid2D_isInside,             METH_VARARGS,"returns 1 or 0 if (x,y) inside grid or not"},
 		{ "binValue",             Grid2D_binValue,             METH_VARARGS,"bins the value into the 2D mesh"},
 		{ "binValueBilinear",     Grid2D_binValueBilinear,     METH_VARARGS,"bins the value into the 2D mesh bi-linearly"},
-		{ "binBunch",             Grid2D_binBunch,             METH_VARARGS,"bins the Bunch instance into the 2D mesh"},
-		{ "binBunchBilinear",     Grid2D_binBunchBilinear,     METH_VARARGS,"bins the Bunch instance into the 2D mesh bi-linearly"},
+		{ "binBunch",             Grid2D_binBunch,             METH_VARARGS,"bins the Bunch instance into the 2D mesh (XY plane by default)"},
+		{ "binBunchBilinear",     Grid2D_binBunchBilinear,     METH_VARARGS,"bins the Bunch instance into the 2D mesh bi-linearly (XY plane by default)"},
 		{ "calcGradient",         Grid2D_calcGradient,         METH_VARARGS,"returns gradient as (gx,gy) for point (x,y) calculated by 9-points weighting scheme"},
 		{ "calcGradientBilinear", Grid2D_calcGradientBilinear, METH_VARARGS,"returns gradient as (gx,gy) for point (x,y) calculated bi-linerly"},
 		{ "synchronizeMPI",       Grid2D_synchronizeMPI,       METH_VARARGS,"synchronize through the MPI communicator"},		

--- a/src/spacecharge/wrap_grid3D.cc
+++ b/src/spacecharge/wrap_grid3D.cc
@@ -268,11 +268,11 @@ extern "C" {
 		PyObject* pyBunch;
 		double lambda;
 		if(!PyArg_ParseTuple(args,"Od:binWrappedBunch",&pyBunch,&lambda)){
-			ORBIT_MPI_Finalize("PyGrid3D - binWrappedBunch(Bunch* bunch) - parameters are needed.");
+			ORBIT_MPI_Finalize("PyGrid3D - binWrappedBunch(Bunch* bunch, lambda) - parameters are needed.");
 		}
 		PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
 		if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
-			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch) - method needs a Bunch.");
+			ORBIT_MPI_Finalize("PyGrid3D - binWrappedBunch(Bunch* bunch, lambda) - method needs a Bunch.");
 		}
 		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
 		cpp_Grid3D->binWrappedBunch(cpp_bunch,lambda);

--- a/src/spacecharge/wrap_grid3D.cc
+++ b/src/spacecharge/wrap_grid3D.cc
@@ -155,7 +155,7 @@ extern "C" {
 		Grid3D* cpp_Grid3D = (Grid3D*) pyGrid3D->cpp_obj;
 		int ind = -1;
 		if(!PyArg_ParseTuple(args,"i:getGridZ",&ind) || ind < 0 || ind >= cpp_Grid3D->getSizeZ()){
-			ORBIT_MPI_Finalize("PyGrid3D - getGridZ(iy) - parameter is needed. [0 - sizeZ[");
+			ORBIT_MPI_Finalize("PyGrid3D - getGridZ(iz) - parameter is needed. [0 - sizeZ[");
 		}		
 		return Py_BuildValue("d",cpp_Grid3D->getGridZ(ind));
 	}	
@@ -243,14 +243,13 @@ extern "C" {
 		return Py_BuildValue("d",cpp_Grid3D->getMaxZ());
 	}		
 	
-	
 	//binBunch(Bunch* bunch)
   static PyObject* Grid3D_binBunch(PyObject *self, PyObject *args){
     pyORBIT_Object* pyGrid3D = (pyORBIT_Object*) self;
 		Grid3D* cpp_Grid3D = (Grid3D*) pyGrid3D->cpp_obj;
 		PyObject* pyBunch;
 		if(!PyArg_ParseTuple(args,"O:binBunch",&pyBunch)){
-			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch) - parameter are needed.");
+			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch) - parameter is needed.");
 		}
 		PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
 		if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
@@ -261,6 +260,25 @@ extern "C" {
 		Py_INCREF(Py_None);
     return Py_None;	
 	}		
+	
+	//binWrappedBunch(Bunch* bunch)
+  static PyObject* Grid3D_binWrappedBunch(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyGrid3D = (pyORBIT_Object*) self;
+		Grid3D* cpp_Grid3D = (Grid3D*) pyGrid3D->cpp_obj;
+		PyObject* pyBunch;
+		double lambda;
+		if(!PyArg_ParseTuple(args,"Od:binWrappedBunch",&pyBunch,&lambda)){
+			ORBIT_MPI_Finalize("PyGrid3D - binWrappedBunch(Bunch* bunch) - parameters are needed.");
+		}
+		PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+		if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
+			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch) - method needs a Bunch.");
+		}
+		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+		cpp_Grid3D->binWrappedBunch(cpp_bunch,lambda);
+		Py_INCREF(Py_None);
+    return Py_None;	
+	}			
 	
 	//binValue(double value, double x, double y, double z)
   static PyObject* Grid3D_binValue(PyObject *self, PyObject *args){
@@ -301,29 +319,30 @@ extern "C" {
 	// defenition of the methods of the python Grid3D wrapper class
 	// they will be vailable from python level
   static PyMethodDef Grid3DClassMethods[] = {
-		{ "setZero",       Grid3D_setZero,       METH_VARARGS,"sets all points on the grid to zero"},
-		{ "getValue",      Grid3D_getValue,      METH_VARARGS,"returns value for (x,y,z) point"},
-		{ "getValueOnGrid",Grid3D_getValueOnGrid,METH_VARARGS,"returns value for indeces (ix,iy,iz) "},
-		{ "setValue",      Grid3D_setValue,      METH_VARARGS,"sets value for (ix,iy,iz) point - (val,ix,iy,iz)"},
-		{ "setGridX",      Grid3D_setGridX,      METH_VARARGS,"sets the X grid with min,max"},
-		{ "setGridY",      Grid3D_setGridY,      METH_VARARGS,"sets the Y grid with min,max"},
-		{ "setGridZ",      Grid3D_setGridZ,      METH_VARARGS,"sets the Z grid with min,max"},
-		{ "getGridX",      Grid3D_getGridX,      METH_VARARGS,"returns the x-grid point with index ind"},
-		{ "getGridY",      Grid3D_getGridY,      METH_VARARGS,"returns the x-grid point with index ind"},
-		{ "getGridZ",      Grid3D_getGridZ,      METH_VARARGS,"sets the Z grid with min,max"},
-		{ "getSizeX",      Grid3D_getSizeX,      METH_VARARGS,"returns the size of grid in X dir."},
-		{ "getSizeY",      Grid3D_getSizeY,      METH_VARARGS,"returns the size of grid in Y dir."},
-		{ "getSizeZ",      Grid3D_getSizeZ,      METH_VARARGS,"returns the size of grid in Z dir."},
-		{ "getMinX",       Grid3D_getMinX,       METH_VARARGS,"returns the min grid point in X dir."},
-		{ "getMaxX",       Grid3D_getMaxX,       METH_VARARGS,"returns the max grid point in X dir."},
-		{ "getMinY",       Grid3D_getMinY,       METH_VARARGS,"returns the min grid point in Y dir."},
-		{ "getMaxY",       Grid3D_getMaxY,       METH_VARARGS,"returns the max grid point in Y dir."},
-		{ "getMinZ",       Grid3D_getMinZ,       METH_VARARGS,"returns the min grid point in Z dir."},
-		{ "getMaxZ",       Grid3D_getMaxZ,       METH_VARARGS,"returns the max grid point in Z dir."},
-		{ "binValue",      Grid3D_binValue,      METH_VARARGS,"bins the value into the 3D mesh"},
-		{ "binBunch",      Grid3D_binBunch,      METH_VARARGS,"bins the Bunch instance into the 3D mesh"},
-		{ "calcGradient",  Grid3D_calcGradient,  METH_VARARGS,"returns gradient as (gx,gy,gz) for point (x,y,z)"},
-		{ "synchronizeMPI",Grid3D_synchronizeMPI,METH_VARARGS,"synchronize through the MPI communicator"},		
+		{ "setZero",        Grid3D_setZero,        METH_VARARGS,"sets all points on the grid to zero"},
+		{ "getValue",       Grid3D_getValue,       METH_VARARGS,"returns value for (x,y,z) point"},
+		{ "getValueOnGrid", Grid3D_getValueOnGrid, METH_VARARGS,"returns value for indeces (ix,iy,iz) "},
+		{ "setValue",       Grid3D_setValue,       METH_VARARGS,"sets value for (ix,iy,iz) point - (val,ix,iy,iz)"},
+		{ "setGridX",       Grid3D_setGridX,       METH_VARARGS,"sets the X grid with min,max"},
+		{ "setGridY",       Grid3D_setGridY,       METH_VARARGS,"sets the Y grid with min,max"},
+		{ "setGridZ",       Grid3D_setGridZ,       METH_VARARGS,"sets the Z grid with min,max"},
+		{ "getGridX",       Grid3D_getGridX,       METH_VARARGS,"returns the x-grid point with index ind"},
+		{ "getGridY",       Grid3D_getGridY,       METH_VARARGS,"returns the x-grid point with index ind"},
+		{ "getGridZ",       Grid3D_getGridZ,       METH_VARARGS,"sets the Z grid with min,max"},
+		{ "getSizeX",       Grid3D_getSizeX,       METH_VARARGS,"returns the size of grid in X dir."},
+		{ "getSizeY",       Grid3D_getSizeY,       METH_VARARGS,"returns the size of grid in Y dir."},
+		{ "getSizeZ",       Grid3D_getSizeZ,       METH_VARARGS,"returns the size of grid in Z dir."},
+		{ "getMinX",        Grid3D_getMinX,        METH_VARARGS,"returns the min grid point in X dir."},
+		{ "getMaxX",        Grid3D_getMaxX,        METH_VARARGS,"returns the max grid point in X dir."},
+		{ "getMinY",        Grid3D_getMinY,        METH_VARARGS,"returns the min grid point in Y dir."},
+		{ "getMaxY",        Grid3D_getMaxY,        METH_VARARGS,"returns the max grid point in Y dir."},
+		{ "getMinZ",        Grid3D_getMinZ,        METH_VARARGS,"returns the min grid point in Z dir."},
+		{ "getMaxZ",        Grid3D_getMaxZ,        METH_VARARGS,"returns the max grid point in Z dir."},
+		{ "binValue",       Grid3D_binValue,       METH_VARARGS,"bins the value into the 3D mesh"},
+		{ "binBunch",       Grid3D_binBunch,       METH_VARARGS,"bins the Bunch into the 3D mesh"},
+		{ "binWrappedBunch",Grid3D_binWrappedBunch,METH_VARARGS,"bins the longitudinally wrapped Bunch into the 3D mesh"},
+		{ "calcGradient",   Grid3D_calcGradient,   METH_VARARGS,"returns gradient as (gx,gy,gz) for point (x,y,z)"},
+		{ "synchronizeMPI", Grid3D_synchronizeMPI, METH_VARARGS,"synchronize through the MPI communicator"},		
     {NULL}
   };
 

--- a/src/spacecharge/wrap_grid3D.cc
+++ b/src/spacecharge/wrap_grid3D.cc
@@ -241,41 +241,43 @@ extern "C" {
     pyORBIT_Object* pyGrid3D = (pyORBIT_Object*) self;
 		Grid3D* cpp_Grid3D = (Grid3D*) pyGrid3D->cpp_obj;	
 		return Py_BuildValue("d",cpp_Grid3D->getMaxZ());
-	}		
+	}
+	
+	//longWrapping([isWrapped]) set or return the longitudinal wrapping policy
+  static PyObject* Grid3D_longWrapping(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyGrid3D = (pyORBIT_Object*) self;
+		Grid3D* cpp_Grid3D = (Grid3D*) pyGrid3D->cpp_obj;	
+		PyObject* pyIsWrapped = NULL;
+		if(!PyArg_ParseTuple(args,"|O:longWrapping",&pyIsWrapped)){
+			ORBIT_MPI_Finalize("PyGrid3D - longWrapping([True/False]) - parameter may be needed.");
+		}
+		if(pyIsWrapped != NULL){
+			int isWrapped = PyObject_IsTrue(pyIsWrapped);
+			if(isWrapped != 1) isWrapped = 0;
+			cpp_Grid3D->setLongWrapping(isWrapped);
+		}
+		return Py_BuildValue("i",cpp_Grid3D->getLongWrapping());
+	}	
 	
 	//binBunch(Bunch* bunch)
   static PyObject* Grid3D_binBunch(PyObject *self, PyObject *args){
     pyORBIT_Object* pyGrid3D = (pyORBIT_Object*) self;
 		Grid3D* cpp_Grid3D = (Grid3D*) pyGrid3D->cpp_obj;
 		PyObject* pyBunch;
-		if(!PyArg_ParseTuple(args,"O:binBunch",&pyBunch)){
-			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch) - parameter is needed.");
+		double lambda = -1.0;
+		if(!PyArg_ParseTuple(args,"O|d:binBunch",&pyBunch,&lambda)){
+			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch [,lambda]) - parameters are needed.");
 		}
 		PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
 		if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
-			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch) - method needs a Bunch.");
+			ORBIT_MPI_Finalize("PyGrid3D - binBunch(Bunch* bunch [,lambda]) - method needs a Bunch.");
 		}
 		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
-		cpp_Grid3D->binBunch(cpp_bunch);
-		Py_INCREF(Py_None);
-    return Py_None;	
-	}		
-	
-	//binWrappedBunch(Bunch* bunch)
-  static PyObject* Grid3D_binWrappedBunch(PyObject *self, PyObject *args){
-    pyORBIT_Object* pyGrid3D = (pyORBIT_Object*) self;
-		Grid3D* cpp_Grid3D = (Grid3D*) pyGrid3D->cpp_obj;
-		PyObject* pyBunch;
-		double lambda;
-		if(!PyArg_ParseTuple(args,"Od:binWrappedBunch",&pyBunch,&lambda)){
-			ORBIT_MPI_Finalize("PyGrid3D - binWrappedBunch(Bunch* bunch, lambda) - parameters are needed.");
+		if(lambda > 0.){
+			cpp_Grid3D->binBunch(cpp_bunch,lambda);
+		} else {
+			cpp_Grid3D->binBunch(cpp_bunch);
 		}
-		PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
-		if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
-			ORBIT_MPI_Finalize("PyGrid3D - binWrappedBunch(Bunch* bunch, lambda) - method needs a Bunch.");
-		}
-		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
-		cpp_Grid3D->binWrappedBunch(cpp_bunch,lambda);
 		Py_INCREF(Py_None);
     return Py_None;	
 	}			
@@ -305,7 +307,7 @@ extern "C" {
 		cpp_Grid3D->calcGradient(x,ex,y,ey,z,ez);
 		return Py_BuildValue("(ddd)",ex,ey,ez);
 	}
-	
+
   //-----------------------------------------------------
   //destructor for python Grid3D class (__del__ method).
   //-----------------------------------------------------
@@ -327,8 +329,8 @@ extern "C" {
 		{ "setGridY",       Grid3D_setGridY,       METH_VARARGS,"sets the Y grid with min,max"},
 		{ "setGridZ",       Grid3D_setGridZ,       METH_VARARGS,"sets the Z grid with min,max"},
 		{ "getGridX",       Grid3D_getGridX,       METH_VARARGS,"returns the x-grid point with index ind"},
-		{ "getGridY",       Grid3D_getGridY,       METH_VARARGS,"returns the x-grid point with index ind"},
-		{ "getGridZ",       Grid3D_getGridZ,       METH_VARARGS,"sets the Z grid with min,max"},
+		{ "getGridY",       Grid3D_getGridY,       METH_VARARGS,"returns the y-grid point with index ind"},
+		{ "getGridZ",       Grid3D_getGridZ,       METH_VARARGS,"returns the z-grid point with index ind"},
 		{ "getSizeX",       Grid3D_getSizeX,       METH_VARARGS,"returns the size of grid in X dir."},
 		{ "getSizeY",       Grid3D_getSizeY,       METH_VARARGS,"returns the size of grid in Y dir."},
 		{ "getSizeZ",       Grid3D_getSizeZ,       METH_VARARGS,"returns the size of grid in Z dir."},
@@ -340,8 +342,8 @@ extern "C" {
 		{ "getMaxZ",        Grid3D_getMaxZ,        METH_VARARGS,"returns the max grid point in Z dir."},
 		{ "binValue",       Grid3D_binValue,       METH_VARARGS,"bins the value into the 3D mesh"},
 		{ "binBunch",       Grid3D_binBunch,       METH_VARARGS,"bins the Bunch into the 3D mesh"},
-		{ "binWrappedBunch",Grid3D_binWrappedBunch,METH_VARARGS,"bins the longitudinally wrapped Bunch into the 3D mesh"},
 		{ "calcGradient",   Grid3D_calcGradient,   METH_VARARGS,"returns gradient as (gx,gy,gz) for point (x,y,z)"},
+		{ "longWrapping",   Grid3D_longWrapping,   METH_VARARGS,"set/get isWrapping variable defining long. wrapping policy"},
 		{ "synchronizeMPI", Grid3D_synchronizeMPI, METH_VARARGS,"synchronize through the MPI communicator"},		
     {NULL}
   };

--- a/src/spacecharge/wrap_poissonsolverfft3d.cc
+++ b/src/spacecharge/wrap_poissonsolverfft3d.cc
@@ -20,7 +20,7 @@ extern "C" {
 	//---------------------------------------------------------
 	//Python PoissonSolverFFT3D class definition
 	//---------------------------------------------------------
-
+	
 	//constructor for python class wrapping PoissonSolverFFT3D instance
 	//It never will be called directly
 	static PyObject* PoissonSolverFFT3D_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
@@ -31,10 +31,10 @@ extern "C" {
 		//std::cerr<<"The PoissonSolverFFT3D new has been called!"<<std::endl;
 		return (PyObject *) self;
 	}
-
-  //initializator for python  PoissonSolverFFT3D class
-  //this is implementation of the __init__ method
-  static int PoissonSolverFFT3D_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
+	
+	//initializator for python  PoissonSolverFFT3D class
+	//this is implementation of the __init__ method
+	static int PoissonSolverFFT3D_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
 		int xSize, ySize, zSize;
 		double xMin = -1.0, xMax = +1.0;
 		double yMin = -1.0, yMax = +1.0;
@@ -46,7 +46,35 @@ extern "C" {
 		((PoissonSolverFFT3D*) self->cpp_obj)->setPyWrapper((PyObject*) self);
 		//std::cerr<<"The PoissonSolverFFT3D __init__ has been called!"<<std::endl;
 		return 0;
-  }
+	}
+  
+ 	//set or get the number of neighboring bunches to account in the potential 
+	static PyObject* PoissonSolverFFT3D_numExtBunches(PyObject *self, PyObject *args){
+		int nBunches = -1;
+		if(!PyArg_ParseTuple(args,"|i:numExtBunches",&nBunches)){
+			ORBIT_MPI_Finalize("PyPoissonSolverFFT3D - numExtBunches([nBunches]) - set/get the number of neighboring bunches.");
+		}
+		pyORBIT_Object* pyPoissonSolverFFT3D = (pyORBIT_Object*) self;
+		PoissonSolverFFT3D* cpp_PoissonSolverFFT3D = (PoissonSolverFFT3D*) pyPoissonSolverFFT3D->cpp_obj;
+		if(nBunches >= 0){
+			cpp_PoissonSolverFFT3D->setNumberOfExternalBunches(nBunches);
+		}
+		return Py_BuildValue("i",cpp_PoissonSolverFFT3D->getNumberOfExternalBunches());
+	}
+	
+ 	//set or get the distance between neighboring bunches
+	static PyObject* PoissonSolverFFT3D_distBetweenBunches(PyObject *self, PyObject *args){
+		double lambda = -1.0;
+		if(!PyArg_ParseTuple(args,"|d:",&lambda)){
+			ORBIT_MPI_Finalize("PyPoissonSolverFFT3D - distBetweenBunches([lambda]) - set/get distance between bunches.");
+		}
+		pyORBIT_Object* pyPoissonSolverFFT3D = (pyORBIT_Object*) self;
+		PoissonSolverFFT3D* cpp_PoissonSolverFFT3D = (PoissonSolverFFT3D*) pyPoissonSolverFFT3D->cpp_obj;
+		if(lambda > 0.){
+			cpp_PoissonSolverFFT3D->setSpacingOfExternalBunches(lambda);
+		}
+		return Py_BuildValue("d",cpp_PoissonSolverFFT3D->getSpacingOfExternalBunches());
+	}	
 		
 	//get grid size in X 
 	static PyObject* PoissonSolverFFT3D_getSizeX(PyObject *self, PyObject *args){
@@ -168,6 +196,8 @@ extern "C" {
 	// defenition of the methods of the python PoissonSolverFFT3D wrapper class
 	// they will be vailable from python level
   static PyMethodDef PoissonSolverFFT3DClassMethods[] = {
+ 		{ "numExtBunches",       PoissonSolverFFT3D_numExtBunches,       METH_VARARGS,"set/get number of neighboring bunches"},
+ 		{ "distBetweenBunches",  PoissonSolverFFT3D_distBetweenBunches,  METH_VARARGS,"set/get distance between bunches"},
 		{ "getSizeX",            PoissonSolverFFT3D_getSizeX,            METH_VARARGS,"returns the number of grid points in x-direction"},
 		{ "getSizeY",            PoissonSolverFFT3D_getSizeY,            METH_VARARGS,"returns the number of grid points in y-direction"},
 		{ "getSizeZ",            PoissonSolverFFT3D_getSizeZ,            METH_VARARGS,"returns the number of grid points in z-direction"},

--- a/src/spacecharge/wrap_poissonsolverfft3d.cc
+++ b/src/spacecharge/wrap_poissonsolverfft3d.cc
@@ -159,7 +159,16 @@ extern "C" {
 		PoissonSolverFFT3D* cpp_PoissonSolverFFT3D = (PoissonSolverFFT3D*) pyPoissonSolverFFT3D->cpp_obj;
 		return Py_BuildValue("d",cpp_PoissonSolverFFT3D->getStepZ());
 	}			
-		
+
+	// updateGreenFunction()
+	static PyObject* PoissonSolverFFT3D_updateGreenFunction(PyObject *self, PyObject *args){
+		pyORBIT_Object* pyPoissonSolverFFT3D = (pyORBIT_Object*) self;
+		PoissonSolverFFT3D* cpp_PoissonSolverFFT3D = (PoissonSolverFFT3D*) pyPoissonSolverFFT3D->cpp_obj;
+		cpp_PoissonSolverFFT3D->updateGreenFunction();
+		Py_INCREF(Py_None);
+    return Py_None;
+	}			
+
 	//findPotential(Grid3D* rhoGrid3D,Grid3D* phiGrid3D)
   static PyObject* PoissonSolverFFT3D_findPotential(PyObject *self, PyObject *args){
     pyORBIT_Object* pyPoissonSolverFFT3D = (pyORBIT_Object*) self;
@@ -210,6 +219,7 @@ extern "C" {
 		{ "getStepX",            PoissonSolverFFT3D_getStepX,            METH_VARARGS,"returns grid step in x-direction"},
 		{ "getStepY",            PoissonSolverFFT3D_getStepY,            METH_VARARGS,"returns grid step in y-direction"},
 		{ "getStepZ",            PoissonSolverFFT3D_getStepZ,            METH_VARARGS,"returns grid step in z-direction"},
+		{ "updateGeenFunction",  PoissonSolverFFT3D_updateGreenFunction, METH_VARARGS,"updates the Green function FFT"},
 		{ "findPotential",       PoissonSolverFFT3D_findPotential,       METH_VARARGS,"findPotential(Grid3D rhoGrid3D,Grid3D phiGrid3D)"},
     {NULL}
   };

--- a/src/spacecharge/wrap_spacechargecalc3d.cc
+++ b/src/spacecharge/wrap_spacechargecalc3d.cc
@@ -105,7 +105,35 @@ extern "C" {
 		Py_INCREF(Py_None);
 		return Py_None;
   }
+  
+	//set/get number of neighboring bunches
+  static PyObject* SpaceChargeCalc3D_numExtBunches(PyObject *self, PyObject *args){
+		pyORBIT_Object* pySpaceChargeCalc3D = (pyORBIT_Object*) self;
+		SpaceChargeCalc3D* cpp_SpaceChargeCalc3D = (SpaceChargeCalc3D*) pySpaceChargeCalc3D->cpp_obj;
+		int nBunches = -1;
+		if(!PyArg_ParseTuple(args,"|i:numExtBunches",&nBunches)){
+			ORBIT_MPI_Finalize("PySpaceChargeCalc3D.numExtBunches([nBunches]) - method has a problem.");
+		}
+		if(nBunches > 0){
+			cpp_SpaceChargeCalc3D->setNumberOfExternalBunches(nBunches);
+		}
+		return Py_BuildValue("i",cpp_SpaceChargeCalc3D->getNumberOfExternalBunches());
+  }	  
 
+	//set/get frequency of bunches in Hz
+  static PyObject* SpaceChargeCalc3D_freqOfBunches(PyObject *self, PyObject *args){
+		pyORBIT_Object* pySpaceChargeCalc3D = (pyORBIT_Object*) self;
+		SpaceChargeCalc3D* cpp_SpaceChargeCalc3D = (SpaceChargeCalc3D*) pySpaceChargeCalc3D->cpp_obj;
+		double  freqiency = -1;
+		if(!PyArg_ParseTuple(args,"|d:freqOfBunches",&freqiency)){
+			ORBIT_MPI_Finalize("PySpaceChargeCalc3D.freqOfBunches([frequency in Hz]) - method has a problem.");
+		}
+		if(freqiency > 0.){
+			cpp_SpaceChargeCalc3D->setFrequencyOfBunches(freqiency);
+		}
+		return Py_BuildValue("d",cpp_SpaceChargeCalc3D->getFrequencyOfBunches());
+  }	  
+  
 	//setRatioLimit(double ratioLimit) sets the ratio change of x to y and x to z to recalculate Green Functions 
   static PyObject* SpaceChargeCalc3D_setRatioLimit(PyObject *self, PyObject *args){
 		pyORBIT_Object* pySpaceChargeCalc3D = (pyORBIT_Object*) self;
@@ -140,9 +168,11 @@ extern "C" {
   // defenition of the methods of the python SpaceChargeCalc3D wrapper class
   // they will be vailable from python level
   static PyMethodDef SpaceChargeCalc3DClassMethods[] = {
-		{ "trackBunch",  SpaceChargeCalc3D_trackBunch, METH_VARARGS,"track the bunch - trackBunch(pyBunch,length,pipe_radius)"},
-		{ "getRhoGrid",  SpaceChargeCalc3D_getRhoGrid, METH_VARARGS,"returns the Grid3D with a space charge density"},
-		{ "getPhiGrid",  SpaceChargeCalc3D_getPhiGrid, METH_VARARGS,"returns the Grid3D with a space charge potential"},
+		{ "trackBunch",     SpaceChargeCalc3D_trackBunch,    METH_VARARGS,"track the bunch - trackBunch(pyBunch,length,pipe_radius)"},
+ 		{ "numExtBunches",  SpaceChargeCalc3D_numExtBunches, METH_VARARGS,"set/get number of neighboring bunches"},
+ 		{ "freqOfBunches",  SpaceChargeCalc3D_freqOfBunches, METH_VARARGS,"set/get frequency of bunches in Hz"},
+		{ "getRhoGrid",     SpaceChargeCalc3D_getRhoGrid,    METH_VARARGS,"returns the Grid3D with a space charge density"},
+		{ "getPhiGrid",     SpaceChargeCalc3D_getPhiGrid,    METH_VARARGS,"returns the Grid3D with a space charge potential"},
 		{ "setRatioLimit",	SpaceChargeCalc3D_setRatioLimit, METH_VARARGS,"sets the ratio change of x to y and x to z to recalculate Green Functions."},
 		{ "getRatioLimit",	SpaceChargeCalc3D_getRatioLimit, METH_VARARGS,"returns the ratio change of x to y and x to z to recalculate Green Functions."},
 		{NULL}

--- a/src/utils/bunch/BunchExtremaCalculator.hh
+++ b/src/utils/bunch/BunchExtremaCalculator.hh
@@ -40,7 +40,13 @@ namespace OrbitUtils{
 			void getExtremaXYZ(Bunch* bunch, 
 				double& xMin, double& xMax, 
 				double& yMin, double& yMax, 
-				double& zMin, double& zMax)	;
+				double& zMin, double& zMax);
+			
+			/** The method calculates the extrema of the particles coordinates xp, yp, dE in the bunch. */
+			void getExtremaXpYpdE(Bunch* bunch, 
+			double& xpMin, double& xpMax, 
+			double& ypMin, double& ypMax, 
+			double& dE_Min, double& dE_Max);
 			
 			/** The method calculates the z extrema of the particles coordinates in the bunch. */
 			void getExtremaZ(Bunch* bunch,  

--- a/src/utils/bunch/wrap_bunch_extrema_calculator.cc
+++ b/src/utils/bunch/wrap_bunch_extrema_calculator.cc
@@ -57,6 +57,23 @@ extern "C" {
 		return Py_BuildValue("(d,d,d,d,d,d)", xMin, xMax, yMin, yMax, zMin, zMax);
   }
   
+	//Calculates xpMin,xpMax,  ypMin,ypMax, dE_Min, dE_Max,
+  static PyObject* BunchExtremaCalculator_extremaXpYpdE(PyObject *self, PyObject *args){
+		PyObject *pyIn;
+		if(!PyArg_ParseTuple(args,"O:extremaXYZ",&pyIn)){
+			error("PyBunchExtremaCalculator - extremaXYZ(Bunch) - Bunch is needed.");
+		}			
+		PyObject* pyBunchType = wrap_orbit_bunch::getBunchType("Bunch");
+		if((!PyObject_IsInstance(pyIn,pyBunchType))){
+			error("PyBunchExtremaCalculator - extremaXpYpdE(Bunch) - input parameter is not Bunch");
+		}		
+		Bunch* bunch = (Bunch*) ((pyORBIT_Object*) pyIn)->cpp_obj;
+		BunchExtremaCalculator* cpp_BunchExtremaCalculator = (BunchExtremaCalculator*) (((pyORBIT_Object*) self)->cpp_obj);
+		double xpMin,xpMax,ypMin,ypMax,dE_Min,dE_Max;
+		cpp_BunchExtremaCalculator->getExtremaXpYpdE(bunch, xpMin, xpMax, ypMin, ypMax, dE_Min, dE_Max);	
+		return Py_BuildValue("(d,d,d,d,d,d)", xpMin, xpMax, ypMin, ypMax, dE_Min, dE_Max);
+  }  
+  
 	//Calculates zMin,zMax
   static PyObject* BunchExtremaCalculator_extremaZ(PyObject *self, PyObject *args){
 		PyObject *pyIn;
@@ -85,8 +102,9 @@ extern "C" {
 	// defenition of the methods of the python BunchExtremaCalculator wrapper class
 	// they will be vailable from python level
   static PyMethodDef BunchExtremaCalculatorClassMethods[] = {
-    { "extremaXYZ",   BunchExtremaCalculator_extremaXYZ  ,METH_VARARGS,"Returns tuple with (xMin, xMax, yMin, yMax, zMin, zMax)"},
-    { "extremaZ",   BunchExtremaCalculator_extremaZ  ,METH_VARARGS,"Returns tuple with (zMin, zMax)"},
+    { "extremaXYZ",      BunchExtremaCalculator_extremaXYZ    ,METH_VARARGS,"Returns tuple with (xMin, xMax, yMin, yMax, zMin, zMax)"},
+    { "extremaXpYpdE",   BunchExtremaCalculator_extremaXpYpdE ,METH_VARARGS,"Returns tuple with (xpMin, xpMax, ypMin, ypMax, dE_Min, dE_Max)"},
+    { "extremaZ",        BunchExtremaCalculator_extremaZ      ,METH_VARARGS,"Returns tuple with (zMin, zMax)"},
     {NULL}
   };
 


### PR DESCRIPTION
The most important changes are account for neighboring bunches in 3D FFT Space Charge calculator, a new particle binning scheme for z-direction in Grid1D and Grid3D, custom binning indexes for Grid1D and Grid2D, modification of the lattice reversal logic to accommodate lattices with RF acceleration and soft-edge quad fields for backtracking.  For now only BaseRfGap RF gap model allows backtracking. RfGapTTF and distributed RF fields need more work.  