### PR TITLE
Add envelope solver c++ routines

### DIFF
--- a/src/spacecharge/EnvSolverKV.cc
+++ b/src/spacecharge/EnvSolverKV.cc
@@ -1,0 +1,17 @@
+#include "EnvSolverKV.hh"
+
+EnvSolverKV::EnvSolverKV(double eps_x, double eps_y, double perveance): CppPyWrapper(NULL)
+{ 
+    ex = eps_x;
+    ey = eps_y;
+    Q = perveance;
+}
+    
+void EnvSolverKV::trackBunch(Bunch* bunch, double length)
+{
+    double a = std::abs(bunch->x(0));
+    double b = std::abs(bunch->y(0));
+
+    bunch->xp(0) += ((16*ex*ex / (a*a*a)) + 2*Q/(a+b)) * length;
+    bunch->yp(0) += ((16*ey*ey / (b*b*b)) + 2*Q/(a+b)) * length;
+}

--- a/src/spacecharge/EnvSolverKV.hh
+++ b/src/spacecharge/EnvSolverKV.hh
@@ -1,0 +1,32 @@
+/** KV envelope solver
+
+ Reference: 
+ S. M. Lund and B. Bukh, Phys. Rev. ST Accel. Beams 7, 024801 (2004).
+*/
+
+#ifndef ENVSOLVER_KV_H
+#define ENVSOLVER_KV_H
+
+#include "Bunch.hh"
+#include "CppPyWrapper.hh"
+
+using namespace std;
+
+class EnvSolverKV: public OrbitUtils::CppPyWrapper
+{
+    public:
+    
+    double ex, ey, Q;
+
+    /** Constructor */
+    EnvSolverKV(double eps_x, double eps_y, double perveance);
+
+    /** Apply space charge kick.
+     
+     The method tracks a single particle who's x and y coordinates represent
+     the horizontal and vertical beam radii of the ellipse.
+    */
+    void trackBunch(Bunch* bunch, double length);
+};
+//end of ENVSOLVER_KV_H
+#endif

--- a/src/spacecharge/EnvSolverRotating.cc
+++ b/src/spacecharge/EnvSolverRotating.cc
@@ -1,0 +1,33 @@
+#include "EnvSolverRotating.hh"
+
+EnvSolverRotating::EnvSolverRotating(double perveance): CppPyWrapper(NULL)
+{
+    Q = perveance;
+}
+    
+void EnvSolverRotating::trackBunch(Bunch* bunch, double length)
+{
+    double a, b, e, f;
+    double phi, cosP, sinP, cosP2, sinP2;
+    double cx, cy, factor;
+
+    a = bunch->x(0);
+    b = bunch->x(1);
+    e = bunch->y(0);
+    f = bunch->y(1);
+
+    phi = -0.5 * atan2(2*(a*e + b*f), (a*a + b*b - e*e - f*f));
+    cosP = cos(phi);
+    sinP = sin(phi);
+    cosP2 = cosP*cosP;
+    sinP2 = sinP*sinP;
+    
+    cx = sqrt(pow(a*f-b*e, 2) / ((e*e+f*f)*cosP2 + (a*a+b*b)*sinP2 +  2*(a*e+b*f)*cosP*sinP));
+    cy = sqrt(pow(a*f-b*e, 2) / ((a*a+b*b)*cosP2 + (e*e+f*f)*sinP2 -  2*(a*e+b*f)*cosP*sinP));
+    factor = 2 * Q / (cx + cy);
+
+    bunch->xp(0) += (factor * ((a*cosP2 - e*sinP*cosP)/cx + (a*sinP2 + e*sinP*cosP)/cy)) * length;
+    bunch->xp(1) += (factor * ((b*cosP2 - f*sinP*cosP)/cx + (b*sinP2 + f*sinP*cosP)/cy)) * length;
+    bunch->yp(0) += (factor * ((e*cosP2 + a*sinP*cosP)/cy + (e*sinP2 - a*sinP*cosP)/cx)) * length;
+    bunch->yp(1) += (factor * ((f*cosP2 + b*sinP*cosP)/cy + (f*sinP2 - b*sinP*cosP)/cx)) * length;
+}

--- a/src/spacecharge/EnvSolverRotating.hh
+++ b/src/spacecharge/EnvSolverRotating.hh
@@ -1,0 +1,39 @@
+/** Envelope solver for the 2D rotating distribution.
+ 
+ Reference: 
+ V. Danilov, S. Cousineau, S. Henderson, and J. Holmes, Self-consistent time dependent
+ two dimensional and three dimensional space charge distributions with linear force,
+ Physical Review Special Topics - Accelerators and Beams 6, 74–85 (2003).
+*/
+
+#ifndef ENVSOLVER_ROTATING_H
+#define ENVSOLVER_ROTATING_H
+
+#include "Bunch.hh"
+#include "CppPyWrapper.hh"
+
+using namespace std;
+
+class EnvSolverRotating: public OrbitUtils::CppPyWrapper
+{
+    public:
+    
+    double Q; // beam perveance
+
+    /** Constructor */
+    EnvSolverRotating(double perveance);
+
+    /** Apply space charge kick.
+     
+     The boundary of a tilted ellipse in real space can be parameterized as:
+        x = a*cos(psi) + b*sin(psi),
+        y = e*cos(psi) + f*sin(psi),
+     where 0 <= psi <= 2pi. The method tracks two particles. The particle coordinates
+     map to the parameters {a, b, e, f} and their slopes in the following way:
+        particle 1 --> {x:a, x':a', y:e, y':e'},
+        particle 2 --> {x:e, x':e', y:f, y':f'}.
+    */
+    void trackBunch(Bunch* bunch, double length);
+};
+//end of ENVSOLVER_ROTATING_H
+#endif

--- a/src/spacecharge/wrap_envsolver_kv.cc
+++ b/src/spacecharge/wrap_envsolver_kv.cc
@@ -1,0 +1,153 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+#
+#include "wrap_envsolver_kv.hh"
+#include "wrap_spacecharge.hh"
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "EnvSolverKV.hh"
+
+using namespace OrbitUtils;
+
+namespace wrap_spacecharge{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    //---------------------------------------------------------
+    //Python EnvSolverKV class definition
+    //---------------------------------------------------------
+
+    //constructor for python class wrapping EnvSolverKV instance
+    //It never will be called directly
+
+    static PyObject* EnvSolverKV_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+    {
+        pyORBIT_Object* self;
+        self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+        self->cpp_obj = NULL;
+        //std::cerr<<"The EnvSolverKV new has been called!"<<std::endl;
+        return (PyObject *) self;
+    }
+    
+  //initializator for python EnvSolverKV class
+  //this is implementation of the __init__ method EnvSolverKV(double ex, double ey, double perveance)
+  static int EnvSolverKV_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds)
+  {
+      double ex, ey, Q;
+        if (!PyArg_ParseTuple(args, "ddd:__init__", &ex, &ey, &Q)) {
+            ORBIT_MPI_Finalize("PyEnvSolverKV - EnvSolverKV(ex, ey, Q) - constructor needs parameters.");
+        }
+      self->cpp_obj = new EnvSolverKV(ex, ey, Q);
+      ((EnvSolverKV*) self->cpp_obj)->setPyWrapper((PyObject*) self);
+      //std::cerr<<"The EnvSolverKV __init__ has been called!"<<std::endl;
+      return 0;
+    }
+    
+    //trackBunch(Bunch* bunch, double length)
+    static PyObject* EnvSolverKV_trackBunch(PyObject *self, PyObject *args) {
+        int nVars = PyTuple_Size(args);
+        pyORBIT_Object* pyEnvSolverKV = (pyORBIT_Object*) self;
+        EnvSolverKV* cpp_EnvSolverKV = (EnvSolverKV*) pyEnvSolverKV->cpp_obj;
+        PyObject* pyBunch;
+        double length;
+        
+        if (!PyArg_ParseTuple(args, "Od:trackBunch", &pyBunch, &length)){
+            ORBIT_MPI_Finalize("PyEnvSolverKV.trackBunch(pyBunch, length) - method needs parameters.");
+        }
+        PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+        if (!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
+            ORBIT_MPI_Finalize("PyEnvSolverKV.trackBunch(pyBunch,length) - pyBunch is not Bunch.");
+        }
+        Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+        cpp_EnvSolverKV->trackBunch(cpp_bunch, length);
+        Py_INCREF(Py_None);
+        return Py_None;
+  }
+
+  //-----------------------------------------------------
+  //destructor for python EnvSolverKV class (__del__ method).
+  //-----------------------------------------------------
+  static void EnvSolverKV_del(pyORBIT_Object* self){
+        EnvSolverKV* cpp_EnvSolverKV = (EnvSolverKV*) self->cpp_obj;
+        if(cpp_EnvSolverKV != NULL){
+            delete cpp_EnvSolverKV;
+        }
+        self->ob_type->tp_free((PyObject*)self);
+  }
+  
+  // defenition of the methods of the python EnvSolverKV wrapper class
+  // they will be vailable from python level
+  static PyMethodDef EnvSolverKVClassMethods[] = {
+        { "trackBunch",  EnvSolverKV_trackBunch, METH_VARARGS,"track the bunch - trackBunch(pyBunch, length)"},
+        {NULL}
+  };
+  
+  // defenition of the memebers of the python EnvSolverKV wrapper class
+  // they will be vailable from python level
+  static PyMemberDef EnvSolverKVClassMembers [] = {
+        {NULL}
+  };
+
+    //new python EnvSolverKV wrapper type definition
+    static PyTypeObject pyORBIT_EnvSolverKV_Type = {
+        PyObject_HEAD_INIT(NULL)
+        0, /*ob_size*/
+        "EnvSolverKV", /*tp_name*/
+        sizeof(pyORBIT_Object), /*tp_basicsize*/
+        0, /*tp_itemsize*/
+        (destructor) EnvSolverKV_del , /*tp_dealloc*/
+        0, /*tp_print*/
+        0, /*tp_getattr*/
+        0, /*tp_setattr*/
+        0, /*tp_compare*/
+        0, /*tp_repr*/
+        0, /*tp_as_number*/
+        0, /*tp_as_sequence*/
+        0, /*tp_as_mapping*/
+        0, /*tp_hash */
+        0, /*tp_call*/
+        0, /*tp_str*/
+        0, /*tp_getattro*/
+        0, /*tp_setattro*/
+        0, /*tp_as_buffer*/
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+        "The EnvSolverKV python wrapper", /* tp_doc */
+        0, /* tp_traverse */
+        0, /* tp_clear */
+        0, /* tp_richcompare */
+        0, /* tp_weaklistoffset */
+        0, /* tp_iter */
+        0, /* tp_iternext */
+        EnvSolverKVClassMethods, /* tp_methods */
+        EnvSolverKVClassMembers, /* tp_members */
+        0, /* tp_getset */
+        0, /* tp_base */
+        0, /* tp_dict */
+        0, /* tp_descr_get */
+        0, /* tp_descr_set */
+        0, /* tp_dictoffset */
+        (initproc) EnvSolverKV_init, /* tp_init */
+        0, /* tp_alloc */
+        EnvSolverKV_new, /* tp_new */
+    };
+
+    //--------------------------------------------------
+    //Initialization function of the pyEnvSolverKV class
+    //It will be called from SpaceCharge wrapper initialization
+    //--------------------------------------------------
+  void initEnvSolverKV(PyObject* module){
+        if (PyType_Ready(&pyORBIT_EnvSolverKV_Type) < 0) return;
+        Py_INCREF(&pyORBIT_EnvSolverKV_Type);
+        PyModule_AddObject(module, "EnvSolverKV", (PyObject *)&pyORBIT_EnvSolverKV_Type);
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+//end of namespace wrap_spacecharge
+}

--- a/src/spacecharge/wrap_envsolver_kv.hh
+++ b/src/spacecharge/wrap_envsolver_kv.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ENVSOLVER_KV_H
+#define WRAP_ENVSOLVER_KV_H
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_spacecharge{
+    void initEnvSolverKV(PyObject* module);
+  }
+    
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // WRAP_ENVSOLVER_KV_H

--- a/src/spacecharge/wrap_envsolver_rotating.cc
+++ b/src/spacecharge/wrap_envsolver_rotating.cc
@@ -1,0 +1,153 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+#
+#include "wrap_envsolver_kv.hh"
+#include "wrap_spacecharge.hh"
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "EnvSolverRotating.hh"
+
+using namespace OrbitUtils;
+
+namespace wrap_spacecharge{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    //---------------------------------------------------------
+    //Python EnvSolverRotating class definition
+    //---------------------------------------------------------
+
+    //constructor for python class wrapping EnvSolverRotating instance
+    //It never will be called directly
+
+    static PyObject* EnvSolverRotating_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+    {
+        pyORBIT_Object* self;
+        self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+        self->cpp_obj = NULL;
+        //std::cerr<<"The EnvSolverRotating new has been called!"<<std::endl;
+        return (PyObject *) self;
+    }
+    
+  //initializator for python EnvSolverRotating class
+  //this is implementation of the __init__ method EnvSolverRotating(double perveance)
+  static int EnvSolverRotating_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds)
+  {
+      double ex, ey, Q;
+        if (!PyArg_ParseTuple(args, "d:__init__", &Q)) {
+            ORBIT_MPI_Finalize("PyEnvSolverRotating - EnvSolverRotating(Q) - constructor needs parameters.");
+        }
+      self->cpp_obj = new EnvSolverRotating(Q);
+      ((EnvSolverRotating*) self->cpp_obj)->setPyWrapper((PyObject*) self);
+      //std::cerr<<"The EnvSolverRotating __init__ has been called!"<<std::endl;
+      return 0;
+    }
+    
+    //trackBunch(Bunch* bunch, double length)
+    static PyObject* EnvSolverRotating_trackBunch(PyObject *self, PyObject *args) {
+        int nVars = PyTuple_Size(args);
+        pyORBIT_Object* pyEnvSolverRotating = (pyORBIT_Object*) self;
+        EnvSolverRotating* cpp_EnvSolverRotating = (EnvSolverRotating*) pyEnvSolverRotating->cpp_obj;
+        PyObject* pyBunch;
+        double length;
+        
+        if (!PyArg_ParseTuple(args, "Od:trackBunch", &pyBunch, &length)){
+            ORBIT_MPI_Finalize("PyEnvSolverRotating.trackBunch(pyBunch, length) - method needs parameters.");
+        }
+        PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+        if (!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
+            ORBIT_MPI_Finalize("PyEnvSolverRotating.trackBunch(pyBunch,length) - pyBunch is not Bunch.");
+        }
+        Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+        cpp_EnvSolverRotating->trackBunch(cpp_bunch, length);
+        Py_INCREF(Py_None);
+        return Py_None;
+  }
+
+  //-----------------------------------------------------
+  //destructor for python EnvSolverRotating class (__del__ method).
+  //-----------------------------------------------------
+  static void EnvSolverRotating_del(pyORBIT_Object* self){
+        EnvSolverRotating* cpp_EnvSolverRotating = (EnvSolverRotating*) self->cpp_obj;
+        if(cpp_EnvSolverRotating != NULL){
+            delete cpp_EnvSolverRotating;
+        }
+        self->ob_type->tp_free((PyObject*)self);
+  }
+  
+  // defenition of the methods of the python EnvSolverRotating wrapper class
+  // they will be vailable from python level
+  static PyMethodDef EnvSolverRotatingClassMethods[] = {
+        { "trackBunch",  EnvSolverRotating_trackBunch, METH_VARARGS,"track the bunch - trackBunch(pyBunch, length)"},
+        {NULL}
+  };
+  
+  // defenition of the memebers of the python EnvSolverRotating wrapper class
+  // they will be vailable from python level
+  static PyMemberDef EnvSolverRotatingClassMembers [] = {
+        {NULL}
+  };
+
+    //new python EnvSolverRotating wrapper type definition
+    static PyTypeObject pyORBIT_EnvSolverRotating_Type = {
+        PyObject_HEAD_INIT(NULL)
+        0, /*ob_size*/
+        "EnvSolverRotating", /*tp_name*/
+        sizeof(pyORBIT_Object), /*tp_basicsize*/
+        0, /*tp_itemsize*/
+        (destructor) EnvSolverRotating_del , /*tp_dealloc*/
+        0, /*tp_print*/
+        0, /*tp_getattr*/
+        0, /*tp_setattr*/
+        0, /*tp_compare*/
+        0, /*tp_repr*/
+        0, /*tp_as_number*/
+        0, /*tp_as_sequence*/
+        0, /*tp_as_mapping*/
+        0, /*tp_hash */
+        0, /*tp_call*/
+        0, /*tp_str*/
+        0, /*tp_getattro*/
+        0, /*tp_setattro*/
+        0, /*tp_as_buffer*/
+        Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+        "The EnvSolverRotating python wrapper", /* tp_doc */
+        0, /* tp_traverse */
+        0, /* tp_clear */
+        0, /* tp_richcompare */
+        0, /* tp_weaklistoffset */
+        0, /* tp_iter */
+        0, /* tp_iternext */
+        EnvSolverRotatingClassMethods, /* tp_methods */
+        EnvSolverRotatingClassMembers, /* tp_members */
+        0, /* tp_getset */
+        0, /* tp_base */
+        0, /* tp_dict */
+        0, /* tp_descr_get */
+        0, /* tp_descr_set */
+        0, /* tp_dictoffset */
+        (initproc) EnvSolverRotating_init, /* tp_init */
+        0, /* tp_alloc */
+        EnvSolverRotating_new, /* tp_new */
+    };
+
+    //--------------------------------------------------
+    //Initialization function of the pyEnvSolverRotating class
+    //It will be called from SpaceCharge wrapper initialization
+    //--------------------------------------------------
+  void initEnvSolverRotating(PyObject* module){
+        if (PyType_Ready(&pyORBIT_EnvSolverRotating_Type) < 0) return;
+        Py_INCREF(&pyORBIT_EnvSolverRotating_Type);
+        PyModule_AddObject(module, "EnvSolverRotating", (PyObject *)&pyORBIT_EnvSolverRotating_Type);
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+//end of namespace wrap_spacecharge
+}

--- a/src/spacecharge/wrap_envsolver_rotating.hh
+++ b/src/spacecharge/wrap_envsolver_rotating.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ENVSOLVER_ROTATING_H
+#define WRAP_ENVSOLVER_ROTATING_H
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_spacecharge{
+    void initEnvSolverRotating(PyObject* module);
+  }
+    
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // WRAP_ENVSOLVER_ROTATING_H

--- a/src/spacecharge/wrap_spacecharge.cc
+++ b/src/spacecharge/wrap_spacecharge.cc
@@ -16,6 +16,8 @@
 #include "wrap_lspacechargecalc.hh"
 #include "wrap_uniform_ellipsoid_field_calculator.hh"
 #include "wrap_spacechargecalc_uniform_ellipse.hh"
+#include "wrap_envsolver_kv.hh"
+#include "wrap_envsolver_rotating.hh"
 
 static PyMethodDef spacechargeMethods[] = { {NULL,NULL} };
 
@@ -41,6 +43,8 @@ extern "C" {
 		wrap_spacecharge::initSpaceChargeCalc3D(module);
 		wrap_spacecharge::initUniformEllipsoidFieldCalculator(module);
 		wrap_spacecharge::initSpaceChargeCalcUniformEllipse(module);
+        wrap_spacecharge::initEnvSolverKV(module);
+        wrap_spacecharge::initEnvSolverRotating(module);
 		wrap_lspacechargecalc::initLSpaceChargeCalc(module);
   }
 	


### PR DESCRIPTION
These files implement space charge calculators based on the envelope equations. Two types of envelope equations are included: the KV envelope equations and the rotating envelope equations. I have included references in the header files. The associated files for each case are:

1) KV envelope equations
    * EnvSolverKV.cc
    * EnvSolverKV.hh
    * wrap_envsolver_kv.cc
    * wrap_envsolver_kv.hh
2) Rotating envelope equations
    * EnvSolverRotating.cc
    * EnvSolverRotating.cc
    * wrap_envsolver_rotating.cc
    * wrap_envsolver_rotating.hh
