### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,3 @@
+. $(pwd)/setupEnvironment.sh
+make clean
+make

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,0 +1,40 @@
+name: build-pyorbit
+on: push
+jobs:
+ centos-8:
+    runs-on: ubuntu-latest
+    container:
+      image: centos:centos8
+    steps:
+         - uses: actions/checkout@v2
+         - name: Install packages
+           run: |
+             yum install -y gcc gcc-c++ make python2 python2-devel mpich mpich-devel zlib-devel fftw-devel
+
+         - name: Make
+           run: |
+             .github/workflows/build.sh
+         - name: Test
+           run: |
+             .github/workflows/run-tests.sh
+
+ ubuntu-2004:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
+    steps:
+         - uses: actions/checkout@v2
+         - name: Install packages
+           run: |
+             pwd
+             apt update
+             DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+             apt install -y build-essential python-dev libmpich-dev mpich  zlib1g-dev libfftw3-dev
+
+         - name: Make
+           run: |
+             .github/workflows/build.sh
+
+         - name: Test
+           run: |
+             .github/workflows/run-tests.sh

--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -1,0 +1,3 @@
+. $(pwd)/setupEnvironment.sh
+cd examples/AccLattice_Tests
+./START.sh lattice_test.py 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: required
-language: cpp
-services: docker
-before_install:
-  - docker build -t pyorbit .
-script:
-  - docker run pyorbit  bash -c "source setupEnvironment.sh; cd examples/AccLattice_Tests; ./START.sh lattice_test.py 2"
-  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/PyORBIT-Collaboration/py-orbit.svg?branch=master)](https://travis-ci.org/PyORBIT-Collaboration/py-orbit)
+![Build](../../actions/workflows/compilation.yml/badge.svg)
 
 # Py-ORBIT  Installation
 


### PR DESCRIPTION
This will re-enable automatic build and check if example runs.
We will use GitHub actions instead of Travis CI.
Also it will try to build on Centos 8 and Ubuntu 20.04