### PR TITLE
Fixed a rounding issue that is causing the inverse to fail to be created under certain circumstances

### DIFF
--- a/src/utils/OU_Function.cc
+++ b/src/utils/OU_Function.cc
@@ -502,6 +502,9 @@ int Function::setInverse(Function* f_inv)
 		f_inv->clean();
 		for(int i = 0; i < size; i++){
 			double xx = getMinY() + i*(getMaxY() - getMinY())/(size - 1);
+			if (i==size-1) {
+				xx=getMaxY();
+			}			
 			f_inv->add(xx,0.);
 		}
 		f_inv->setConstStep(1);

--- a/src/utils/OU_Function.cc
+++ b/src/utils/OU_Function.cc
@@ -500,13 +500,11 @@ int Function::setInverse(Function* f_inv)
 	//create x-arr if it is not ready
 	if(f_inv->getSize() < 2){
 		f_inv->clean();
-		for(int i = 0; i < size; i++){
-			double xx = getMinY() + i*(getMaxY() - getMinY())/(size - 1);
-			if (i==size-1) {
-				xx=getMaxY();
-			}			
+		for(int i = 0; i < size-1; i++){
+			double xx = getMinY() + i*(getMaxY() - getMinY())/(size - 1);		
 			f_inv->add(xx,0.);
 		}
+		f_inv->add(getMaxY(),0.);
 		f_inv->setConstStep(1);
 	}
 	


### PR DESCRIPTION
The formula for creating the x axis of the functions inverse is such that for the very last point rounding errors can cause the last value to not be set to the max Y value of the function being inverted. This can cause a check later on to see if the inverses max X value is greater than the original functions Max Y value to fail. This is resolved by simply setting the final x value of the functions inverse to the orginal functions Max Y value. This is completely consistent with formula for calculating the x value of the inverse but avoids potential rounding/precious errors.

Formula:
double xx =getMinY() +i*(getMaxY()-getMinY())/(size-1)
when i =size -1 the formula should give: xx = getMaxY() but due to precision loss/rounding this isn't always the case which causes the check:
 if(f_inv->getMaxX() > getMaxY())
to evaluate to true and the function inverse to fail to be constructed
