### PR TITLE
Rutherford scattering now updates the px and py, instead of updating the px twice

### DIFF
--- a/src/orbit/MaterialInteractions/Foil.cc
+++ b/src/orbit/MaterialInteractions/Foil.cc
@@ -285,7 +285,7 @@ void Foil::traverseFoilFullScatter(Bunch* bunch, Bunch* lostbunch){
 							double angley = atan(ypfac) + thy;
 							
 							part_coord_arr[ip][1] = tan(anglex) * pfac;
-							part_coord_arr[ip][1] = tan(angley) * pfac;
+							part_coord_arr[ip][3] = tan(angley) * pfac;
 						}
 						
 						// Nuclear Inelastic absorption


### PR DESCRIPTION
It looks like a typo in the foil scattering calculation.