### PR TITLE
The "TurnNumber" particles attributes were added. This attribute allo…

### DIFF
--- a/py/orbit/injection/injectparticles.py
+++ b/py/orbit/injection/injectparticles.py
@@ -170,6 +170,11 @@ class InjectParts:
 			bunch.partAttrValue("ParticleInitialCoordinates",particle_index, 3,py)
 			bunch.partAttrValue("ParticleInitialCoordinates",particle_index, 4,z)
 			bunch.partAttrValue("ParticleInitialCoordinates",particle_index, 5,dE)
+		if(bunch.hasPartAttr("TurnNumberAttributes") != 0 and 
+			bunch.hasBunchAttrInt("TurnNumber") != 0):
+			particle_index = bunch.getSize() - 1
+			turn = 1.0*bunch.bunchAttrInt("TurnNumber")
+			bunch.partAttrValue("TurnNumberAttributes", particle_index, 0, turn)		
 	
 	def addLostParticle(self,bunch,lostbunch,x,px,y,py,z,dE):
 		"""
@@ -185,7 +190,10 @@ class InjectParts:
 			lostbunch.addPartAttr("ParticleIdNumber")
 		if(bunch.hasPartAttr("ParticleInitialCoordinates") != 0 and 
 			lostbunch.hasPartAttr("ParticleInitialCoordinates") == 0):
-			lostbunch.addPartAttr("ParticleInitialCoordinates")	
+			lostbunch.addPartAttr("ParticleInitialCoordinates")
+		if(bunch.hasPartAttr("TurnNumberAttributes") != 0 and 
+			lostbunch.hasPartAttr("TurnNumberAttributes") == 0):
+			lostbunch.addPartAttr("TurnNumberAttributes")
 		#----------------------------------------------------
 		
 		lostbunch.addParticle(x,px,y,py,z,dE)
@@ -202,5 +210,11 @@ class InjectParts:
 			lostbunch.partAttrValue("ParticleInitialCoordinates",particle_index, 2,y)
 			lostbunch.partAttrValue("ParticleInitialCoordinates",particle_index, 3,py)
 			lostbunch.partAttrValue("ParticleInitialCoordinates",particle_index, 4,z)
-			lostbunch.partAttrValue("ParticleInitialCoordinates",particle_index, 5,dE)	
+			lostbunch.partAttrValue("ParticleInitialCoordinates",particle_index, 5,dE)
+			
+		if(lostbunch.hasPartAttr("TurnNumberAttributes") != 0 and
+			bunch.hasBunchAttrInt("TurnNumber") != 0):
+			particle_index = lostbunch.getSize() - 1
+			turn = 1.0*bunch.bunchAttrInt("TurnNumber")
+			lostbunch.partAttrValue("TurnNumberAttributes", particle_index, 0, turn)
 

--- a/py/orbit/teapot/__init__.py
+++ b/py/orbit/teapot/__init__.py
@@ -14,6 +14,7 @@ from teapot import QuadTEAPOT
 from teapot import RingRFTEAPOT
 from teapot import SolenoidTEAPOT
 from teapot import TiltTEAPOT
+from teapot import NodeTEAPOT
 
 from teapot import TPB
 
@@ -32,6 +33,7 @@ __all__.append("KickTEAPOT")
 __all__.append("RingRFTEAPOT")
 __all__.append("FringeFieldTEAPOT")
 __all__.append("TiltTEAPOT")
+__all__.append("NodeTEAPOT")
 __all__.append("TPB")
 __all__.append("TEAPOT_MATRIX_Lattice")
 

--- a/py/orbit/teapot/teapot.py
+++ b/py/orbit/teapot/teapot.py
@@ -168,7 +168,9 @@ class TEAPOT_Ring(TEAPOT_Lattice):
 			bunchwrapper = BunchWrapTEAPOT("Bunch Wrap")
 			bunchwrapper.getParamsDict()["ring_length"] = self.getLength()
 			node.addChildNode(bunchwrapper, AccNode.BODY)			
-
+		#---- adding turn counter node at the end of lattice
+		turn_counter = TurnCounterTEAPOT()
+		self.getNodes().append(turn_counter)
 
 class _teapotFactory:
 	"""
@@ -397,7 +399,6 @@ class _teapotFactory:
 
 	getElements = classmethod(getElements)
 
-
 class BaseTEAPOT(AccNodeBunchTracker):
 	""" The base abstract class of the TEAPOT accelerator elements hierarchy. """
 	def __init__(self, name = "no name"):
@@ -406,6 +407,23 @@ class BaseTEAPOT(AccNodeBunchTracker):
 		"""
 		AccNodeBunchTracker.__init__(self,name)
 		self.setType("base teapot")
+
+class TurnCounterTEAPOT(BaseTEAPOT):
+	def __init__(self, name = "TurnCounter"):
+		"""
+		Constructor. Creates the TEAPOT for turn count in the Ring lattice.
+		"""
+		BaseTEAPOT.__init__(self,name)
+		self.setType("turn counter")
+		
+	def track(self, paramsDict):
+		"""
+		The Turn Counter class implementation of the AccNodeBunchTracker class track(probe) method.
+		"""
+		bunch = paramsDict["bunch"]
+		if(bunch.hasBunchAttrInt("TurnNumber") != 0):
+			turn = bunch.bunchAttrInt("TurnNumber")
+			bunch.bunchAttrInt("TurnNumber",turn + 1)
 
 class NodeTEAPOT(BaseTEAPOT):
 	def __init__(self, name = "no name"):

--- a/src/orbit/MaterialInteractions/Collimator.cc
+++ b/src/orbit/MaterialInteractions/Collimator.cc
@@ -795,6 +795,16 @@ void Collimator::loseParticle(Bunch* bunch, Bunch* lostbunch, int ip, int& nLost
 			partAttr_lost->attValue(lost_part_ind,j) = partAttr->attValue(ip,j);
 		}		
 	}
+
+	if (bunch->hasParticleAttributes("TurnNumberAttributes") > 0) {
+		if (lostbunch->hasParticleAttributes("TurnNumberAttributes") <= 0) {
+			std::map<std::string,double> part_attr_dict;
+			lostbunch->addParticleAttributes("TurnNumberAttributes",part_attr_dict);
+		}
+		std::string attr_name_str("TurnNumber");
+		double turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);
+		lostbunch->getParticleAttributes("TurnNumberAttributes")->attValue(lostbunch->getSize() - 1, 0) = turn;
+	}
 	
 	bunch->deleteParticleFast(ip);
 	nLost++;

--- a/src/orbit/ParticlesAttributes/ParticleAttributesFactory.cc
+++ b/src/orbit/ParticlesAttributes/ParticleAttributesFactory.cc
@@ -27,6 +27,7 @@
 #include "ParticlePhaseAttributes.hh"
 #include "ParticleIdNumber.hh"
 #include "ParticleInitialCoordinates.hh"
+#include "TurnNumberAttributes.hh"
 
 ParticleAttributesFactory::ParticleAttributesFactory()
 {
@@ -180,6 +181,10 @@ ParticleAttributes* ParticleAttributesFactory::getParticleAttributesInstance(
 		part_atrs = new ParticleInitialCoordinates(bunch);
 	}	
 	
+	if(name == "TurnNumber"){
+		part_atrs = new TurnNumberAttributes(bunch);
+	}
+	
 	if(part_atrs == NULL) {
 		if(rank_MPI == 0){
 			std::cerr << "ParticleAttributesFactory::getParticleAttributesInstance(const string name, Bunch* bunch)"<< std::endl;
@@ -212,7 +217,6 @@ void ParticleAttributesFactory::getParticleAttributesNames(std::vector<string>& 
 	names.push_back("LostParticleAttributes");
 	names.push_back("ParticlePhaseAttributes");
 	names.push_back("ParticleInitialCoordinates");
+	names.push_back("TurnNumber");
 }
-
-
 

--- a/src/orbit/ParticlesAttributes/TurnNumberAttributes.cc
+++ b/src/orbit/ParticlesAttributes/TurnNumberAttributes.cc
@@ -1,0 +1,54 @@
+//////////////////////////////// -*- C++ -*- //////////////////////////////
+//
+// FILE NAME
+//  TurnNumberAttributes.cc
+//
+// AUTHOR
+//   Andrei Shishlo
+//
+// CREATED
+//    03/07/2022
+//
+// DESCRIPTION
+//    A subclass of a ParticleAttributes class
+//    
+// The main purpose of this class to provide information about the turn
+// index in the lost bunch for ring simulations. This attribute should be
+// assigned to the tracking main bunch after its instantiating before 
+// tracking. During the tracking the collimation nodes will add this 
+// attribute to the lost bunch (if it does not exist yet) and will assign
+// turn value to the particles lost in this collimator.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include "Bunch.hh"
+#include "TurnNumberAttributes.hh"
+
+TurnNumberAttributes::TurnNumberAttributes(Bunch* bunch): 
+ParticleAttributes(bunch,1)
+{
+  cl_name_ = "TurnNumber";
+  attrDescr = "TurnNumber";
+  std::string attr_name_str("TurnNumber");
+  //we start counting from the 1st turn
+  bunch->setBunchAttribute( attr_name_str, 1);
+}
+
+TurnNumberAttributes::~TurnNumberAttributes()
+{
+}
+
+/**
+	Returns the turn number for the particle with particle_index in the bunch.
+*/
+int TurnNumberAttributes::getTurn(int particle_index){
+
+	return int(attValue(particle_index,0));
+}
+
+/**
+	Sets the turn number for the particle with particle_index in the bunch.
+*/
+void TurnNumberAttributes::setTurn(int particle_index, int turn){
+	attValue(particle_index,0) = 1.0*turn;
+}

--- a/src/orbit/ParticlesAttributes/TurnNumberAttributes.hh
+++ b/src/orbit/ParticlesAttributes/TurnNumberAttributes.hh
@@ -1,0 +1,55 @@
+//////////////////////////////// -*- C++ -*- //////////////////////////////
+//
+// FILE NAME
+//  TurnNumberAttributes.cc
+//
+// AUTHOR
+//   Andrei Shishlo
+//
+// CREATED
+//    03/07/2022
+//
+// DESCRIPTION
+//    A subclass of a ParticleAttributes class
+//    
+// The main purpose of this class to provide information about the turn
+// index in the lost bunch for ring simulations. This attribute should be
+// assigned to the tracking main bunch after its instantiating before 
+// tracking. During the tracking the collimation nodes will add this 
+// attribute to the lost bunch (if it does not exist yet) and will assign
+// turn value to the particles lost in this collimator.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#ifndef TURN_NUMBER_H
+#define TURN_NUMBER_H
+
+#include <string>
+
+#include "ParticleAttributes.hh"
+
+class TurnNumberAttributes : public ParticleAttributes
+{
+public:
+  //--------------------------------------
+  //the public methods of the TurnNumberAttributes class
+  //--------------------------------------
+
+  TurnNumberAttributes(Bunch* bunch);
+  ~TurnNumberAttributes();
+
+	/** Returns the turn number for the particle with particle_index in the bunch */
+  int getTurn(int particle_index);
+	
+	/** Sets the turn number for the particle with particle_index in the bunch */
+	void setTurn(int particle_index, int turn);	
+
+};
+
+///////////////////////////////////////////////////////////////////////////
+//
+// END OF FILE
+//
+///////////////////////////////////////////////////////////////////////////
+
+#endif


### PR DESCRIPTION
…ws to assign the turn number to the particles in the lost bunch that accumulates the particles lost at apertures. The Ring TEAPOT lattice class was modified with Turn Counter TEAPOT node added to the end of an ordinary TEAPOT lattice. This node will track bunch and will increase TurnNumber bunch attribute each time. So, there are bunch integer attribute "TunBunch" and a particles attribute with the same name. The bunch attribute is used to define particles attributes during the injection and collimation.