### PR TITLE
There are several changes to fix bugs related to the Turn Number …

### DIFF
--- a/py/orbit/injection/injectparticles.py
+++ b/py/orbit/injection/injectparticles.py
@@ -170,11 +170,11 @@ class InjectParts:
 			bunch.partAttrValue("ParticleInitialCoordinates",particle_index, 3,py)
 			bunch.partAttrValue("ParticleInitialCoordinates",particle_index, 4,z)
 			bunch.partAttrValue("ParticleInitialCoordinates",particle_index, 5,dE)
-		if(bunch.hasPartAttr("TurnNumberAttributes") != 0 and 
+		if(bunch.hasPartAttr("TurnNumber") != 0 and 
 			bunch.hasBunchAttrInt("TurnNumber") != 0):
 			particle_index = bunch.getSize() - 1
 			turn = 1.0*bunch.bunchAttrInt("TurnNumber")
-			bunch.partAttrValue("TurnNumberAttributes", particle_index, 0, turn)		
+			bunch.partAttrValue("TurnNumber", particle_index, 0, turn)		
 	
 	def addLostParticle(self,bunch,lostbunch,x,px,y,py,z,dE):
 		"""
@@ -191,9 +191,9 @@ class InjectParts:
 		if(bunch.hasPartAttr("ParticleInitialCoordinates") != 0 and 
 			lostbunch.hasPartAttr("ParticleInitialCoordinates") == 0):
 			lostbunch.addPartAttr("ParticleInitialCoordinates")
-		if(bunch.hasPartAttr("TurnNumberAttributes") != 0 and 
-			lostbunch.hasPartAttr("TurnNumberAttributes") == 0):
-			lostbunch.addPartAttr("TurnNumberAttributes")
+		if(bunch.hasPartAttr("TurnNumber") != 0 and 
+			lostbunch.hasPartAttr("TurnNumber") == 0):
+			lostbunch.addPartAttr("TurnNumber")
 		#----------------------------------------------------
 		
 		lostbunch.addParticle(x,px,y,py,z,dE)
@@ -212,9 +212,9 @@ class InjectParts:
 			lostbunch.partAttrValue("ParticleInitialCoordinates",particle_index, 4,z)
 			lostbunch.partAttrValue("ParticleInitialCoordinates",particle_index, 5,dE)
 			
-		if(lostbunch.hasPartAttr("TurnNumberAttributes") != 0 and
+		if(lostbunch.hasPartAttr("TurnNumber") != 0 and
 			bunch.hasBunchAttrInt("TurnNumber") != 0):
 			particle_index = lostbunch.getSize() - 1
 			turn = 1.0*bunch.bunchAttrInt("TurnNumber")
-			lostbunch.partAttrValue("TurnNumberAttributes", particle_index, 0, turn)
+			lostbunch.partAttrValue("TurnNumber", particle_index, 0, turn)
 

--- a/py/orbit/teapot/__init__.py
+++ b/py/orbit/teapot/__init__.py
@@ -4,6 +4,7 @@
 ## These classes use teapot_base C++ wrappers
 
 from teapot import TEAPOT_Lattice
+from teapot import TEAPOT_Ring
 from teapot import BaseTEAPOT
 from teapot import BendTEAPOT
 from teapot import DriftTEAPOT
@@ -22,6 +23,7 @@ from teapot_matrix_lattice import TEAPOT_MATRIX_Lattice
 
 __all__ = []
 __all__.append("TEAPOT_Lattice")
+__all__.append("TEAPOT_Ring")
 __all__.append("BaseTEAPOT")
 __all__.append("DriftTEAPOT")
 __all__.append("BunchWrapTEAPOT")

--- a/py/orbit/time_dep/time_dep.py
+++ b/py/orbit/time_dep/time_dep.py
@@ -5,13 +5,13 @@ import sys
 import os
 import math
 
-from orbit.teapot import TEAPOT_Lattice
+from orbit.teapot import TEAPOT_Ring
 from orbit.parsers.mad_parser import MAD_Parser, MAD_LattLine
 from orbit.lattice import AccNode, AccActionsContainer
 from orbit.time_dep import waveform
 
 
-class TIME_DEP_Lattice(TEAPOT_Lattice):
+class TIME_DEP_Lattice(TEAPOT_Ring):
 	"""
 	The subclass of the TEAPOT_Lattice.
 	TIME_DEP_Lattice has the ability to set time-dependent
@@ -20,7 +20,7 @@ class TIME_DEP_Lattice(TEAPOT_Lattice):
 	"""
 
 	def __init__(self, name = "no name"):
-		TEAPOT_Lattice.__init__(self, name)
+		TEAPOT_Ring.__init__(self, name)
 		self.__latticeDict = {}
 		self.__TDNodeDict = {}
 		self.__turns = 1

--- a/src/orbit/Apertures/Aperture.cc
+++ b/src/orbit/Apertures/Aperture.cc
@@ -70,6 +70,9 @@ void Aperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 	ParticleAttributes* partMacroAttr = NULL;
 	ParticleAttributes* partMacroInitAttr = NULL;	
 	
+	ParticleAttributes* partTurnNumberAttr = NULL;
+	double turn = 0.;
+	
 	if(lostbunch != NULL) {
 		if(lostbunch->hasParticleAttributes("LostParticleAttributes") <= 0){
 			std::map<std::string,double> params_dict;
@@ -102,7 +105,17 @@ void Aperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 				lostbunch->addParticleAttributes("macrosize",params_dict);
 			}
 			partMacroAttr = lostbunch->getParticleAttributes("macrosize");
-		}	
+		}
+		
+		if (bunch->hasParticleAttributes("TurnNumber") > 0) {
+			if (lostbunch->hasParticleAttributes("TurnNumber") <= 0) {
+				std::map<std::string,double> part_attr_dict;
+				lostbunch->addParticleAttributes("TurnNumber",part_attr_dict);
+			}
+			std::string attr_name_str("TurnNumber");
+			turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);
+			partTurnNumberAttr = lostbunch->getParticleAttributes("TurnNumber");
+		}
 		
 		lostbunch->setMacroSize(bunch->getMacroSize());
 	}
@@ -126,6 +139,9 @@ void Aperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 	  			if(partMacroAttr != NULL){
 	  				partMacroAttr->attValue(lostbunch->getSize() - 1, 0) = partMacroInitAttr->attValue(count,0);
 	  			}
+					if(partTurnNumberAttr != NULL){
+						partTurnNumberAttr->attValue(lostbunch->getSize() - 1, 0) = turn;
+					}
 	  		}
 	  		bunch->deleteParticleFast(count);
 	  	}
@@ -151,6 +167,9 @@ void Aperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 	  			if(partMacroAttr != NULL){
 	  				partMacroAttr->attValue(lostbunch->getSize() - 1, 0) = partMacroInitAttr->attValue(count,0);
 	  			}
+					if(partTurnNumberAttr != NULL){
+						partTurnNumberAttr->attValue(lostbunch->getSize() - 1, 0) = turn;
+					}
 	  		}
 	  		bunch->deleteParticleFast(count);
 	  	}
@@ -176,6 +195,9 @@ void Aperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 	  			if(partMacroAttr != NULL){
 	  				partMacroAttr->attValue(lostbunch->getSize() - 1, 0) = partMacroInitAttr->attValue(count,0);
 	  			}
+					if(partTurnNumberAttr != NULL){
+						partTurnNumberAttr->attValue(lostbunch->getSize() - 1, 0) = turn;
+					}
 	  		}
 	  		bunch->deleteParticleFast(count);
 	  	}

--- a/src/orbit/Apertures/PhaseAperture.cc
+++ b/src/orbit/Apertures/PhaseAperture.cc
@@ -114,7 +114,10 @@ void PhaseAperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 	ParticleAttributes* partMacroInitAttr = NULL;	
 	
 	ParticleAttributes* partInitCoordsAttr = NULL;
-	ParticleAttributes* partInitCoordsInitAttr = NULL;		
+	ParticleAttributes* partInitCoordsInitAttr = NULL;
+	
+	ParticleAttributes* partTurnNumberAttr = NULL;
+	double turn = 0.;
 	
 	if(lostbunch != NULL) {
 		if(lostbunch->hasParticleAttributes("LostParticleAttributes") <= 0){
@@ -149,8 +152,18 @@ void PhaseAperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 				lostbunch->addParticleAttributes("ParticleInitialCoordinates",params_dict);
 			}	
 			partInitCoordsAttr = lostbunch->getParticleAttributes("ParticleInitialCoordinates");
-		}			
+		}
 		
+		if (bunch->hasParticleAttributes("TurnNumber") > 0) {
+			if (lostbunch->hasParticleAttributes("TurnNumber") <= 0) {
+				std::map<std::string,double> part_attr_dict;
+				lostbunch->addParticleAttributes("TurnNumber",part_attr_dict);
+			}
+			std::string attr_name_str("TurnNumber");
+			turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);				
+			partTurnNumberAttr = lostbunch->getParticleAttributes("TurnNumber");
+		}		
+			
 		lostbunch->setMacroSize(bunch->getMacroSize());
 	}
 
@@ -179,6 +192,9 @@ void PhaseAperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
 					  partInitCoordsAttr->attValue(lostbunch->getSize() - 1,init_ind) = partInitCoordsInitAttr->attValue(count,init_ind);
 					}
 				}
+				if(partTurnNumberAttr != NULL){
+					partTurnNumberAttr->attValue(lostbunch->getSize() - 1, 0) = turn;
+				}				
 			}
 			bunch->deleteParticleFast(count);
 		}

--- a/src/orbit/MaterialInteractions/Collimator.cc
+++ b/src/orbit/MaterialInteractions/Collimator.cc
@@ -796,14 +796,14 @@ void Collimator::loseParticle(Bunch* bunch, Bunch* lostbunch, int ip, int& nLost
 		}		
 	}
 
-	if (bunch->hasParticleAttributes("TurnNumberAttributes") > 0) {
-		if (lostbunch->hasParticleAttributes("TurnNumberAttributes") <= 0) {
+	if (bunch->hasParticleAttributes("TurnNumber") > 0) {
+		if (lostbunch->hasParticleAttributes("TurnNumber") <= 0) {
 			std::map<std::string,double> part_attr_dict;
-			lostbunch->addParticleAttributes("TurnNumberAttributes",part_attr_dict);
+			lostbunch->addParticleAttributes("TurnNumber",part_attr_dict);
 		}
 		std::string attr_name_str("TurnNumber");
 		double turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);
-		lostbunch->getParticleAttributes("TurnNumberAttributes")->attValue(lostbunch->getSize() - 1, 0) = turn;
+		lostbunch->getParticleAttributes("TurnNumber")->attValue(lostbunch->getSize() - 1, 0) = turn;
 	}
 	
 	bunch->deleteParticleFast(ip);

--- a/src/orbit/MaterialInteractions/Foil.cc
+++ b/src/orbit/MaterialInteractions/Foil.cc
@@ -599,7 +599,17 @@ void Foil::loseParticle(Bunch* bunch, Bunch* lostbunch, int ip, int& nLost, int&
 		ParticleInitialCoordinates* partAttr_lost = (ParticleInitialCoordinates*) lostbunch->getParticleAttributes("ParticleInitialCoordinates");
 		for(int j=0; j < 6; ++j){
 			partAttr_lost->attValue(lost_part_ind,j) = partAttr->attValue(ip,j);
-		}		
+		}
+
+		if (bunch->hasParticleAttributes("TurnNumber") > 0) {
+			if (lostbunch->hasParticleAttributes("TurnNumber") <= 0) {
+				std::map<std::string,double> part_attr_dict;
+				lostbunch->addParticleAttributes("TurnNumber",part_attr_dict);
+			}
+			std::string attr_name_str("TurnNumber");
+			double turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);
+			lostbunch->getParticleAttributes("TurnNumber")->attValue(lostbunch->getSize() - 1, 0) = turn;
+		}
 	}
 	
 	bunch->deleteParticleFast(ip);


### PR DESCRIPTION
There are several changes to fix bugs related to the Turn Numberparticle attribute feature. 1) TIME_DEP_Lattice (package py/orbit/time_dep/time_dep.py) - time dependent lattice used TEAPOT_Lattice as a parent class instead of TEAPOT_Ring. Fixed. 2) In the py/orbit/injection/injectparticles.py we used "TurnNumberAttributes" as a name of attributes instead of "TurnNumber". Fixed. 3) The same problem was in src/orbit/MaterialInteractions/Collimator.cc file. Fixed. 4) In src/orbit/MaterialInteractions/Foil.cc and src/orbit/Apertures/Aperture.cc and PhaseAperture.cc we did not have anything related to transferring turn number information to the lost bunch particles. Fixed.