### PR TITLE
Now the Collimator C++ class does not need lostbunch parameter

### DIFF
--- a/py/orbit/py_linac/materials/VacuumWindowLinacNode.py
+++ b/py/orbit/py_linac/materials/VacuumWindowLinacNode.py
@@ -59,7 +59,7 @@ class VacuumWindowNode(BaseLinacNode):
 		#---- by default the shape is circle
 		shape = 1
 		#---- by default the radius is 0 m 
-		#---- It means no particles will escape the collimator!
+		#---- It means no particles will escape the collimator! See Collimator.cc
 		radius = 0.
 		a = radius
 		b = a
@@ -98,18 +98,14 @@ class VacuumWindowNode(BaseLinacNode):
 		"""
 		The vacuum window class implementation of the AccNodeBunchTracker class track(paramsDict) method.
 		"""
-		if(not paramsDict.has_key("lostbunch")):
-			msg  = "Class VacuumWindowNode:"
-			msg += os.linesep
-			msg += "Method: track(self, paramsDict). We need lostbunch key in paramsDict!)"
-			msg += os.linesep
-			msg += "Stop."
-			msg += os.linesep
-			orbitFinalize(msg)			
 		length = self.getLength(self.getActivePartIndex())
+		if(length <= 0.): return
 		bunch = paramsDict["bunch"]
-		lostbunch = paramsDict["lostbunch"]
-		self.collimator.collimateBunch(bunch, lostbunch)
+		if(paramsDict.has_key("lostbunch")):
+			lostbunch = paramsDict["lostbunch"]
+			self.collimator.collimateBunch(bunch, lostbunch)
+		else:
+			self.collimator.collimateBunch(bunch)
 			
 	def setPosition(self, pos):
 		"""

--- a/src/orbit/MaterialInteractions/Collimator.cc
+++ b/src/orbit/MaterialInteractions/Collimator.cc
@@ -64,7 +64,7 @@ Collimator::Collimator(double length, int ma,
 }
 
 void Collimator::collimateBunch(Bunch* bunch, Bunch* lostbunch){
-
+	
 	int j = 1, coll_flag = 0, lastArg, trackit;
 	double nAvogadro = 6.022045e23;
 	double random, choice, length, dlength, meanfreepath, b_pN;
@@ -766,44 +766,49 @@ void Collimator::takeStep(Bunch* bunch, Bunch* lostbunch, double* coords, SyncPa
 	
 void Collimator::loseParticle(Bunch* bunch, Bunch* lostbunch, int ip, int& nLost, int& coll_flag, double& zrl){
 	double** coords = bunch->coordArr();
-	lostbunch->addParticle(coords[ip][0], coords[ip][1], coords[ip][2], coords[ip][3], coords[ip][4], coords[ip][5]);
-	int lost_part_ind = lostbunch->getSize() - 1;
-	
-	if (lostbunch->hasParticleAttributes("LostParticleAttributes") <= 0) {
-		std::map<std::string,double> part_attr_dict;
-		lostbunch->addParticleAttributes("LostParticleAttributes",part_attr_dict);
-	}
-	//absolute position in lattice where particle is lost
-	lostbunch->getParticleAttributes("LostParticleAttributes")->attValue(lost_part_ind, 0) = pos_ + (length_ - zrl);
-	
-	if (bunch->hasParticleAttributes("ParticleIdNumber") > 0) {
-		if (lostbunch->hasParticleAttributes("ParticleIdNumber") <= 0) {
-			std::map<std::string,double> part_attr_dict;
-			lostbunch->addParticleAttributes("ParticleIdNumber",part_attr_dict);
-		}	
-		lostbunch->getParticleAttributes("ParticleIdNumber")->attValue(lost_part_ind, 0) = bunch->getParticleAttributes("ParticleIdNumber")->attValue(ip,0);
-	}
-	
-	if (bunch->hasParticleAttributes("ParticleInitialCoordinates") > 0) {
-		if (lostbunch->hasParticleAttributes("ParticleInitialCoordinates") <= 0) {
-			std::map<std::string,double> part_attr_dict;
-			lostbunch->addParticleAttributes("ParticleInitialCoordinates",part_attr_dict);
-		}
-		ParticleInitialCoordinates* partAttr = (ParticleInitialCoordinates*) bunch->getParticleAttributes("ParticleInitialCoordinates");
-		ParticleInitialCoordinates* partAttr_lost = (ParticleInitialCoordinates*) lostbunch->getParticleAttributes("ParticleInitialCoordinates");
-		for(int j=0; j < 6; ++j){
-			partAttr_lost->attValue(lost_part_ind,j) = partAttr->attValue(ip,j);
-		}		
-	}
 
-	if (bunch->hasParticleAttributes("TurnNumber") > 0) {
-		if (lostbunch->hasParticleAttributes("TurnNumber") <= 0) {
+	if(lostbunch != NULL){
+
+		lostbunch->addParticle(coords[ip][0], coords[ip][1], coords[ip][2], coords[ip][3], coords[ip][4], coords[ip][5]);
+		int lost_part_ind = lostbunch->getSize() - 1;
+		
+		if (lostbunch->hasParticleAttributes("LostParticleAttributes") <= 0) {
 			std::map<std::string,double> part_attr_dict;
-			lostbunch->addParticleAttributes("TurnNumber",part_attr_dict);
+			lostbunch->addParticleAttributes("LostParticleAttributes",part_attr_dict);
 		}
-		std::string attr_name_str("TurnNumber");
-		double turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);
-		lostbunch->getParticleAttributes("TurnNumber")->attValue(lostbunch->getSize() - 1, 0) = turn;
+		//absolute position in lattice where particle is lost
+		lostbunch->getParticleAttributes("LostParticleAttributes")->attValue(lost_part_ind, 0) = pos_ + (length_ - zrl);
+		
+		if (bunch->hasParticleAttributes("ParticleIdNumber") > 0) {
+			if (lostbunch->hasParticleAttributes("ParticleIdNumber") <= 0) {
+				std::map<std::string,double> part_attr_dict;
+				lostbunch->addParticleAttributes("ParticleIdNumber",part_attr_dict);
+			}	
+			lostbunch->getParticleAttributes("ParticleIdNumber")->attValue(lost_part_ind, 0) = bunch->getParticleAttributes("ParticleIdNumber")->attValue(ip,0);
+		}
+		
+		if (bunch->hasParticleAttributes("ParticleInitialCoordinates") > 0) {
+			if (lostbunch->hasParticleAttributes("ParticleInitialCoordinates") <= 0) {
+				std::map<std::string,double> part_attr_dict;
+				lostbunch->addParticleAttributes("ParticleInitialCoordinates",part_attr_dict);
+			}
+			ParticleInitialCoordinates* partAttr = (ParticleInitialCoordinates*) bunch->getParticleAttributes("ParticleInitialCoordinates");
+			ParticleInitialCoordinates* partAttr_lost = (ParticleInitialCoordinates*) lostbunch->getParticleAttributes("ParticleInitialCoordinates");
+			for(int j=0; j < 6; ++j){
+				partAttr_lost->attValue(lost_part_ind,j) = partAttr->attValue(ip,j);
+			}		
+		}
+	
+		if (bunch->hasParticleAttributes("TurnNumber") > 0) {
+			if (lostbunch->hasParticleAttributes("TurnNumber") <= 0) {
+				std::map<std::string,double> part_attr_dict;
+				lostbunch->addParticleAttributes("TurnNumber",part_attr_dict);
+			}
+			std::string attr_name_str("TurnNumber");
+			double turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);
+			lostbunch->getParticleAttributes("TurnNumber")->attValue(lostbunch->getSize() - 1, 0) = turn;
+		}
+		
 	}
 	
 	bunch->deleteParticleFast(ip);


### PR DESCRIPTION
Now the Collimator C++ class does not need lostbunch parameter by default. User can use NULL as a reference to this bunch. It also means that Vacuum Window will track the bunch even ParamDict does not have "lostbunch" parameter defined.