### PR TITLE
Avoiding injection of identical particles

### DIFF
--- a/py/orbit/injection/injectparticles.py
+++ b/py/orbit/injection/injectparticles.py
@@ -43,7 +43,6 @@ class InjectParts:
 		"""
 		#---- User can skip injection if self.nparts is zero
 		if(self.nparts == 0): return
-		random.seed(100)
 		
 		(xmin,xmax,ymin,ymax) = self.injectregion
 	


### PR DESCRIPTION
Setting of the the same seed number for each injection provided the exact same coordinates for particles which is wrong. The random.seed(100) statement was removed.  This was found by Jeff Holmes.