### PR TITLE
Base apertures

### DIFF
--- a/src/orbit/Apertures/BaseAperture.cc
+++ b/src/orbit/Apertures/BaseAperture.cc
@@ -1,0 +1,234 @@
+#include "BaseAperture.hh"
+#include "ParticleAttributes.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   BaseAperture
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   BaseAperture class defines actions with macro particles in a main bunch 
+//   and a lost bunch instances with respect of transverse coordinates of 
+//   macro particles. It can keep macro particle in the main bunch or remove it
+//   after asking the BaseApertureShape class instance about the suitability 
+//   of particle's coordinates.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** BaseAperture constructor */
+BaseAperture::BaseAperture(): CppPyWrapper(NULL)
+{
+	apertureName = "no_name";
+	isActive = 1;
+	nLost_ = 0;
+	pos_ = 0.;
+	apertureShape = NULL;
+}
+
+/** BaseAperture decstructor */
+BaseAperture::~BaseAperture()
+{
+	if(apertureShape != NULL){
+		Py_XDECREF(apertureShape->getPyWrapper());
+	}
+}
+
+/** Returns aperture shape */
+BaseApertureShape* BaseAperture::getApertureShape(){
+	return apertureShape;
+}
+
+/** Sets aperture shape */
+void BaseAperture::setApertureShape(BaseApertureShape* apertureShapeIn){
+
+	nLost_ = 0;
+	
+	if(apertureShapeIn == NULL){
+		return;
+	}
+	
+	if( ((PyObject*) apertureShapeIn->getPyWrapper()) == NULL){
+		ORBIT_MPI_Finalize("BaseAperture class setApertureShape(...): BaseApertureShape Python class needed! Stop.");
+	}	
+	
+	if(apertureShape != NULL){
+		if( ((PyObject*) apertureShape->getPyWrapper()) != NULL){
+			Py_XDECREF( (PyObject*) apertureShape->getPyWrapper());
+		}
+	}
+
+	apertureShape = apertureShapeIn;
+	Py_INCREF((PyObject*) apertureShape->getPyWrapper());
+}
+
+/** 
+	Routine for transfering particles through a aperture 
+*/
+void BaseAperture::checkBunch(Bunch* bunch, Bunch* lostbunch){
+	
+	nLost_ = 0;
+	
+	if(isActive != 1){
+		return;
+	}
+	
+	if(apertureShape == NULL){
+		return;
+	}	
+
+	bunch->compress();
+	if(lostbunch != NULL) lostbunch->compress();
+	double m_size = 0.;
+	int nParts = bunch->getSize();
+	double** coord = bunch->coordArr();
+	
+	
+	int nPartsGlobal = bunch->getSizeGlobal();
+	
+	ParticleAttributes* lostPartAttr = NULL;
+	
+	ParticleAttributes* partIdNumbAttr = NULL;
+	ParticleAttributes* partIdNumbInitAttr = NULL;
+	
+	ParticleAttributes* partInitCoordsAttr = NULL;
+	ParticleAttributes* partInitCoordsInitAttr = NULL;
+	
+	ParticleAttributes* partMacroAttr = NULL;
+	ParticleAttributes* partMacroInitAttr = NULL;	
+	
+	ParticleAttributes* partTurnNumberAttr = NULL;
+	double turn = 0.;
+	
+	if(lostbunch != NULL) {
+		if(lostbunch->hasParticleAttributes("LostParticleAttributes") <= 0){
+			std::map<std::string,double> params_dict;
+			lostbunch->addParticleAttributes("LostParticleAttributes",params_dict);
+		}
+		lostPartAttr = lostbunch->getParticleAttributes("LostParticleAttributes");
+		
+		if(bunch->hasParticleAttributes("ParticleIdNumber") > 0){
+			partIdNumbInitAttr = bunch->getParticleAttributes("ParticleIdNumber");
+			if(lostbunch->hasParticleAttributes("ParticleIdNumber") <= 0){
+				std::map<std::string,double> params_dict;
+				lostbunch->addParticleAttributes("ParticleIdNumber",params_dict);
+			}	
+			partIdNumbAttr = lostbunch->getParticleAttributes("ParticleIdNumber");
+		}
+		
+		if(bunch->hasParticleAttributes("ParticleInitialCoordinates") > 0){
+			partInitCoordsInitAttr = bunch->getParticleAttributes("ParticleInitialCoordinates");
+			if(lostbunch->hasParticleAttributes("ParticleInitialCoordinates") <= 0){
+				std::map<std::string,double> params_dict;
+				lostbunch->addParticleAttributes("ParticleInitialCoordinates",params_dict);
+			}
+			partInitCoordsAttr = lostbunch->getParticleAttributes("ParticleInitialCoordinates");			
+		}		
+		
+		if(bunch->hasParticleAttributes("macrosize") > 0){
+			partMacroInitAttr = bunch->getParticleAttributes("macrosize");
+			if(lostbunch->hasParticleAttributes("macrosize") <= 0){
+				std::map<std::string,double> params_dict;
+				lostbunch->addParticleAttributes("macrosize",params_dict);
+			}
+			partMacroAttr = lostbunch->getParticleAttributes("macrosize");
+		}
+		
+		if (bunch->hasParticleAttributes("TurnNumber") > 0) {
+			if (lostbunch->hasParticleAttributes("TurnNumber") <= 0) {
+				std::map<std::string,double> part_attr_dict;
+				lostbunch->addParticleAttributes("TurnNumber",part_attr_dict);
+			}
+			std::string attr_name_str("TurnNumber");
+			turn = 1.0*bunch->getBunchAttributeInt(attr_name_str);
+			partTurnNumberAttr = lostbunch->getParticleAttributes("TurnNumber");
+		}
+		
+		lostbunch->setMacroSize(bunch->getMacroSize());
+	}
+
+	//Loop over all particles in the bunch
+	for (int count = 0; count < nParts; count++){
+		//if particle is not inside the shape we remove it from bunch
+		if(apertureShape->inside(bunch,count) != 1){
+			if(lostbunch != NULL) {
+				lostbunch->addParticle(coord[count][0], coord[count][1], coord[count][2], coord[count][3], coord[count][4], coord[count][5]);
+				//pos_ is a position in lattice where particle is lost
+				lostPartAttr->attValue(lostbunch->getSize() - 1, 0) = pos_;
+				if(partIdNumbAttr != NULL){
+					partIdNumbAttr->attValue(lostbunch->getSize() - 1, 0) = partIdNumbInitAttr->attValue(count,0);
+				}
+				if(partInitCoordsAttr != NULL){
+					for(int j=0; j < 6; ++j){
+						partInitCoordsAttr->attValue(lostbunch->getSize() - 1, j) = partInitCoordsInitAttr->attValue(count,j);
+					}
+				}
+				if(partMacroAttr != NULL){
+					partMacroAttr->attValue(lostbunch->getSize() - 1, 0) = partMacroInitAttr->attValue(count,0);
+				}
+				if(partTurnNumberAttr != NULL){
+					partTurnNumberAttr->attValue(lostbunch->getSize() - 1, 0) = turn;
+				}
+			}
+			bunch->deleteParticleFast(count);
+		}
+	}	
+				
+	//compress bunch
+	bunch->compress();
+	
+	//Total particle loss across all CPUs in the bunch communicator
+	nLost_ = nPartsGlobal - bunch->getSizeGlobal();
+}
+
+/** 
+	Returns total particle loss across all CPUs in the bunch communicator 
+*/
+int BaseAperture::getNumberOfLost(){
+	return nLost_;
+}
+
+/** Returns the aperture name */
+string BaseAperture::getName(){
+	return apertureName;
+}
+	
+/** Sets the aperture name */
+void BaseAperture::setName(string apertureNameIn){
+	apertureName = apertureNameIn;
+}
+
+/**
+	Returns the position of the node in the lattice.
+*/
+double BaseAperture::getPosition(){
+	return pos_;
+}
+
+/**
+	Sets the position of the node in the lattice.
+*/
+void BaseAperture::setPosition(double position){
+	pos_ = position;
+}
+	
+/**
+	Sets the aperture in an active ( 1 )/ not active ( 0 ) state
+*/
+void BaseAperture::setOnOff(int isActive){
+	this->isActive = isActive;
+}
+
+/**
+	Returns the aperture in an active ( 1 )/ not active ( 0 ) state
+*/
+int BaseAperture::getOnOff(){
+	return isActive;
+}

--- a/src/orbit/Apertures/BaseAperture.hh
+++ b/src/orbit/Apertures/BaseAperture.hh
@@ -1,0 +1,98 @@
+//The base class for BaseApertures. It defines the interface for BaseAperture
+#ifndef BASE_APERTURE_H
+#define BASE_APERTURE_H
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   BaseAperture
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+   BaseAperture class defines actions with macro particles in a main bunch 
+   and a lost bunch instances with respect of transverse coordinates of 
+   macro particles. It can keep macro particle in the main bunch or remove it
+   after asking the BaseApertureShape class instance about the suitability 
+   of particle's coordinates.
+*/
+    
+class BaseAperture: public OrbitUtils::CppPyWrapper
+{
+public:
+	
+	/** BaseAperture constructor */
+	BaseAperture();
+	
+	/** BaseAperture decstructor */
+	virtual ~BaseAperture();
+
+	/** Returns aperture shape */
+	BaseApertureShape* getApertureShape();
+	
+	/** Sets aperture shape */
+	void setApertureShape(BaseApertureShape* apertureShape);
+	
+	/** Routine for transfering particles through a aperture */
+	void checkBunch(Bunch* bunch, Bunch* lostbunch);
+	
+	/** Returns the total number of partciles lost across all CPUs */
+	int getNumberOfLost();
+
+	/** Returns the aperture name */
+	string getName();
+	
+	/** Sets the aperture name */
+	void setName(string apertureNameIn);
+
+	/** Sets the position of the node in the lattice */
+	double getPosition();
+	
+	/** Returns the position of the node in the lattice */
+	void setPosition(double position);
+
+	/**
+	Sets the aperture in an active ( 1 )/ not active ( 0 ) state
+	*/
+	void setOnOff(int isActive);
+	
+	/**
+	Returns the aperture in an active ( 1 )/ not active ( 0 ) state
+	*/
+	int getOnOff();	
+	
+protected:
+	
+	//name of the aperture
+	string apertureName;	
+	
+	//Counters	
+	int nLost_;
+	
+	//aperture position
+	double pos_;
+
+	//BaseApertureShape 
+	BaseApertureShape* apertureShape;
+	
+	//Info variable defining if the aperture is active or not.
+	//isActive == 1 then it is active otherwise it is not.
+	int isActive;
+
+};
+
+//end of BASE_APERTURE_H ifdef
+#endif
+

--- a/src/orbit/Apertures/BaseApertureShape.cc
+++ b/src/orbit/Apertures/BaseApertureShape.cc
@@ -1,0 +1,85 @@
+#include "BaseApertureShape.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   BaseApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   BaseApertureShape defines the interface for BaseApertureShape subclasses.
+//   It decides if particular particle in the bunch is inside the aperture shape.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** BaseApertureShape constructor */
+BaseApertureShape::BaseApertureShape(): CppPyWrapper(NULL)
+{
+	shapeName = "no_shape";
+	typeName = "no_type";
+	x_center = 0.;
+	y_center = 0.;
+}
+
+/** BaseApertureShape decstructor */
+BaseApertureShape::~BaseApertureShape()
+{
+}
+
+/** Return 1 if the particular macro-particle is inside this shape */
+int BaseApertureShape::inside(Bunch* bunch, int count)
+{
+	return 0;
+}
+
+/** Sets the center of shape in X direction */
+void BaseApertureShape::setCenterX(double x_center)
+{
+	this->x_center = x_center;
+}
+
+/** Returns the center of shape in X direction */
+double BaseApertureShape::getCenterX()
+{
+	return x_center;
+}
+
+/** Sets the center of shape in Y direction */
+void BaseApertureShape::setCenterY(double y_center)
+{
+	this->y_center = y_center;
+}
+
+/** Returns the center of shape in Y direction */
+double BaseApertureShape::getCenterY()
+{
+	return y_center;
+}
+
+
+/** Returns the shape name */
+string BaseApertureShape::getName()
+{
+	return shapeName;
+}
+	
+/** Sets the shape name */
+void BaseApertureShape::setName(string shapeNameIn)
+{
+	shapeName = shapeNameIn;
+}
+
+/** Returns the shape type name */
+string BaseApertureShape::getTypeName()
+{
+	return typeName;
+}
+	
+

--- a/src/orbit/Apertures/BaseApertureShape.hh
+++ b/src/orbit/Apertures/BaseApertureShape.hh
@@ -1,0 +1,74 @@
+//The base class for BaseApertureShapes. It defines the interface for BaseApertureShape
+#ifndef BASE_APERTURE_SHAPE_H
+#define BASE_APERTURE_SHAPE_H
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   BaseApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+   The base class for BaseApertureShapes. 
+   It defines the interface for BaseApertureShape subclasses.
+*/
+    
+class BaseApertureShape: public OrbitUtils::CppPyWrapper
+{
+public:
+	
+	/** BaseApertureShape constructor */
+	BaseApertureShape();
+	
+	/** BaseApertureShape decstructor */
+	virtual ~BaseApertureShape();
+	
+	/** Return 1 if the particular macro-particle is inside this shape */
+	virtual int inside(Bunch* bunch, int count);
+	
+	/** Sets the center of shape in X direction */
+	void setCenterX(double x_center);
+	
+	/** Returns the center of shape in X direction */
+	double getCenterX();
+	
+	/** Sets the center of shape in Y direction */
+	void setCenterY(double y_center);
+	
+	/** Returns the center of shape in Y direction */
+	double getCenterY();	
+
+	/** Returns the shape name */
+	string getName();
+	
+	/** Sets the shape name */
+	void setName(string shapeName);
+	
+	/** Returns the shape type name */
+	string getTypeName();
+	
+protected:
+	
+	string shapeName;
+	
+	string typeName;
+	
+	double x_center, y_center;
+
+};
+
+//end of BASE_APERTURE_SHAPE_H ifdef
+#endif

--- a/src/orbit/Apertures/CircleApertureShape.cc
+++ b/src/orbit/Apertures/CircleApertureShape.cc
@@ -1,0 +1,60 @@
+#include "CircleApertureShape.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   CircleApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   CircleApertureShape is an implementation of BaseApertureShape class.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** CircleApertureShape constructor */
+CircleApertureShape::CircleApertureShape(): BaseApertureShape()
+{
+		shapeName = "circle";
+		typeName = "circle";
+		radius = 0.;
+		radius2 = 0.;		
+}
+
+/** CircleApertureShape decstructor */
+CircleApertureShape::~CircleApertureShape()
+{
+}
+
+/** Return 1 if the particular macro-particle is inside this shape */
+int CircleApertureShape::inside(Bunch* bunch, int count){
+	
+	double** coord = bunch->coordArr();
+	
+	double x = coord[count][0] - x_center;
+	double y = coord[count][2] - y_center;
+	double r2 = x*x + y*y;
+	if(r2 <= radius2){
+		return 1;
+	}
+	return 0;
+}
+
+/** Sets the radius of the circle in [m] */ 
+void CircleApertureShape::setRadius(double radius)
+{
+	this->radius = radius;
+	radius2 = radius*radius;
+}
+
+/** Returns the radius of the circle in [m] */ 
+double CircleApertureShape::getRadius()
+{
+	return radius;
+}

--- a/src/orbit/Apertures/CircleApertureShape.hh
+++ b/src/orbit/Apertures/CircleApertureShape.hh
@@ -1,0 +1,54 @@
+#ifndef CIRCULAR_APERTURE_SHAPE_H
+#define CIRCULAR_APERTURE_SHAPE_H
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   CircleApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+	CircleApertureShape is an implementation of BaseApertureShape class.
+*/
+    
+class CircleApertureShape: public BaseApertureShape
+{
+public:
+	
+	/** CircleApertureShape constructor */
+	CircleApertureShape();
+	
+	/** CircleApertureShape decstructor */
+	virtual ~CircleApertureShape();
+	
+	/** Return 1 if the particular macro-particle is inside this shape */
+	int inside(Bunch* bunch, int count);
+	
+	/** Sets the radius of the circle in [m] */ 
+	void setRadius(double radius);
+	
+	/** Returns the radius of the circle in [m] */ 
+	double getRadius();
+	
+protected:
+	
+	double radius;
+	double radius2;
+
+};
+
+//end of CIRCULAR_APERTURE_SHAPE_H ifdef
+#endif

--- a/src/orbit/Apertures/CompositeApertureShape.cc
+++ b/src/orbit/Apertures/CompositeApertureShape.cc
@@ -45,12 +45,14 @@ int CompositeApertureShape::inside(Bunch* bunch, int count){
 	if(n_shapes == 0){
 		return 0;
 	}
+	int sum = 0;
 	for(int ind = 0; ind < n_shapes; ind++){
-		if(apertureShapes[ind]->inside(bunch,count) != 1){;
-			return 0;
+		sum += apertureShapes[ind]->inside(bunch,count);
+		if(sum > 0){;
+			return 1;
 		}
 	}
-	return 1;
+	return 0;
 }
 
 /** Adds the new aperture shape to the collection */ 

--- a/src/orbit/Apertures/CompositeApertureShape.cc
+++ b/src/orbit/Apertures/CompositeApertureShape.cc
@@ -1,0 +1,67 @@
+#include "CompositeApertureShape.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   CompositeApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   CompositeApertureShape is an implementation of BaseApertureShape class
+//   and a collection of aperture shapes. To get "isinside" method result
+//   1 (Yes) this class will go through all BaseApertureShape class instances
+//   in the collection and should get 1 from each shape from the collection. 
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** CompositeApertureShape constructor */
+CompositeApertureShape::CompositeApertureShape(): BaseApertureShape()
+{
+		shapeName = "composite";
+		typeName = "composite";
+}
+
+/** CompositeApertureShape decstructor */
+CompositeApertureShape::~CompositeApertureShape()
+{	
+	int n_shapes = apertureShapes.size();
+	for(int ind = 0; ind < n_shapes; ind++){
+		if(apertureShapes[ind]->getPyWrapper() != NULL){
+			Py_XDECREF((PyObject*) apertureShapes[ind]->getPyWrapper());
+		}
+	}
+}
+
+/** Return 1 if the particular macro-particle is inside this shape */
+int CompositeApertureShape::inside(Bunch* bunch, int count){
+	int n_shapes = apertureShapes.size();
+	if(n_shapes == 0){
+		return 0;
+	}
+	for(int ind = 0; ind < n_shapes; ind++){
+		if(apertureShapes[ind]->inside(bunch,count) != 1){;
+			return 0;
+		}
+	}
+	return 1;
+}
+
+/** Adds the new aperture shape to the collection */ 
+void CompositeApertureShape::addApertureShape(BaseApertureShape* apertureShape)
+{
+	apertureShapes.push_back(apertureShape);
+	Py_INCREF((PyObject*) apertureShape->getPyWrapper());
+}
+
+/** Returns vector of pointers to aperture shapes that are in this collection */ 
+std::vector<BaseApertureShape*> CompositeApertureShape::getApertureShape()
+{
+	return apertureShapes;
+}

--- a/src/orbit/Apertures/CompositeApertureShape.cc
+++ b/src/orbit/Apertures/CompositeApertureShape.cc
@@ -15,9 +15,10 @@
 //   Andrei Shishlo October 2022
 //
 //   CompositeApertureShape is an implementation of BaseApertureShape class
-//   and a collection of aperture shapes. To get "isinside" method result
-//   1 (Yes) this class will go through all BaseApertureShape class instances
-//   in the collection and should get 1 from each shape from the collection. 
+//   to represent a logical union of several shapes dtored in collection. 
+//   To get "isinside" method result 1 (Yes) this class will go through 
+//   all BaseApertureShape class instances in the collection and 
+//   should get 1 from at least one shape.  
 //
 ///////////////////////////////////////////////////////////////////////////
 
@@ -44,11 +45,10 @@ int CompositeApertureShape::inside(Bunch* bunch, int count){
 	int n_shapes = apertureShapes.size();
 	if(n_shapes == 0){
 		return 0;
-	}
-	int sum = 0;
+	}	
 	for(int ind = 0; ind < n_shapes; ind++){
-		sum += apertureShapes[ind]->inside(bunch,count);
-		if(sum > 0){;
+		int isIn = apertureShapes[ind]->inside(bunch,count);
+		if(isIn > 0){;
 			return 1;
 		}
 	}

--- a/src/orbit/Apertures/CompositeApertureShape.hh
+++ b/src/orbit/Apertures/CompositeApertureShape.hh
@@ -18,14 +18,13 @@ using namespace std;
 // AUTHOR: 
 //   Andrei Shishlo October 2022
 //
+//   CompositeApertureShape is an implementation of BaseApertureShape class
+//   to represent a logical union of several shapes dtored in collection. 
+//   To get "isinside" method result 1 (Yes) this class will go through 
+//   all BaseApertureShape class instances in the collection and 
+//   should get 1 from at least one shape.  
+//
 ///////////////////////////////////////////////////////////////////////////
-
-/** 
- CompositeApertureShape is an implementation of BaseApertureShape class
- and a collection of aperture shapes. To get "isinside" method result
- 1 (Yes) this class will go through all BaseApertureShape class instances
- in the collection and should get 1 from each shape from the collectio	
-*/
     
 class CompositeApertureShape: public BaseApertureShape
 {

--- a/src/orbit/Apertures/CompositeApertureShape.hh
+++ b/src/orbit/Apertures/CompositeApertureShape.hh
@@ -1,0 +1,57 @@
+#ifndef COMPOSITE_APERTURE_SHAPE_H
+#define COMPOSITE_APERTURE_SHAPE_H
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   CompositeApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+ CompositeApertureShape is an implementation of BaseApertureShape class
+ and a collection of aperture shapes. To get "isinside" method result
+ 1 (Yes) this class will go through all BaseApertureShape class instances
+ in the collection and should get 1 from each shape from the collectio	
+*/
+    
+class CompositeApertureShape: public BaseApertureShape
+{
+public:
+	
+	/** CompositeApertureShape constructor */
+	CompositeApertureShape();
+	
+	/** CompositeApertureShape decstructor */
+	virtual ~CompositeApertureShape();
+	
+	/** Return 1 if the particular macro-particle is inside this shape */
+	int inside(Bunch* bunch, int count);
+	
+	/** Adds the new aperture shape to the collection */ 
+	void addApertureShape(BaseApertureShape* apertureShape);
+	
+	
+	/** Returns array of aperture shapes that are in this collection */ 
+	std::vector<BaseApertureShape*> getApertureShape();
+
+protected:
+	
+	 std::vector<BaseApertureShape*> apertureShapes;
+
+};
+
+//end of COMPOSITE_APERTURE_SHAPE_H ifdef
+#endif

--- a/src/orbit/Apertures/ConvexApertureShape.cc
+++ b/src/orbit/Apertures/ConvexApertureShape.cc
@@ -1,0 +1,131 @@
+#include "orbit_mpi.hh"
+
+#include "ConvexApertureShape.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   ConvexApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   ConvexApertureShape is an implementation of BaseApertureShape class
+//   and a collection of (x,y) points describing convex shape. User should 
+//   define these points.
+///////////////////////////////////////////////////////////////////////////
+
+/** ConvexApertureShape constructor */
+ConvexApertureShape::ConvexApertureShape(): BaseApertureShape()
+{
+		shapeName = "convex";
+		typeName = "convex";
+}
+
+/** ConvexApertureShape decstructor */
+ConvexApertureShape::~ConvexApertureShape()
+{
+}
+
+/** Return 1 if the particular macro-particle is inside this shape */
+int ConvexApertureShape::inside(Bunch* bunch, int count){
+	
+	double** coord = bunch->coordArr();
+	
+	double x = coord[count][0] - x_center;
+	double y = coord[count][2] - y_center;
+	
+	int nPoints = convexX.size();
+	for(int ind = 0; ind < (nPoints-1); ind++){
+		if(this->checkOnePoint(ind,ind+1,x,y) != 1){
+			return 0;
+		}
+	}
+	if(nPoints == 2) return 1;
+	return this->checkOnePoint(nPoints-1,0,x,y);
+}
+
+/** Adds the new aperture shape to the collection */ 
+void ConvexApertureShape::addPoint(double x, double y)
+{
+	convexX.push_back(x);
+	convexY.push_back(y);
+}
+
+/** Returns vector of x-coordinates of points */ 
+std::vector<double> ConvexApertureShape::getPointsX()
+{
+	return convexX;
+}
+
+/** Returns vector of y-coordinates of points */ 
+std::vector<double> ConvexApertureShape::getPointsY()
+{
+	return convexY;
+}
+
+/** Removes all (x,y) points */ 
+void ConvexApertureShape::removeAllPoints()
+{
+	convexX.clear();
+	convexY.clear();
+}
+
+/** Checks that we have a convex shape*/ 
+int ConvexApertureShape::checkAllPoints()
+{
+	int nPoints = convexX.size();
+	if(nPoints == 0 || nPoints == 1){
+		ORBIT_MPI_Finalize("ConvexApertureShape.checkAllPoints() - number of convex shape points = 0 or 1. Stop.");
+		return 0;
+	}
+	if(nPoints == 2){
+		return 1;
+	}
+
+	
+	for(int ind = 0; ind < (nPoints-2); ind++){
+		if(this->checkOnePoint(ind,ind+1,ind+2) != 1){
+			ORBIT_MPI_Finalize("ConvexApertureShape.checkAllPoints() - not a convex shape. Stop.");
+			return 0;				
+		}
+	}
+	
+	if(this->checkOnePoint(nPoints - 2, nPoints - 1, 0) != 1){
+		ORBIT_MPI_Finalize("ConvexApertureShape.checkAllPoints() - not a convex shape. Stop.");
+		return 0;
+	}
+	
+	if(this->checkOnePoint(nPoints - 1, 0, nPoints - 2) != 1){
+		ORBIT_MPI_Finalize("ConvexApertureShape.checkAllPoints() - not a convex shape. Stop.");
+		return 0;
+	}
+	return 1;
+}
+
+/** Checks that a point with index i that it is at clockwise half-plain relative to 0->1 line */ 
+int ConvexApertureShape::checkOnePoint(int i0, int i1, int i)
+{
+	double x = convexX[i];
+	double y = convexY[i];
+	return this->checkOnePoint(i0,i1,x,y);
+}
+
+/** Checks that a point (x,y) that it is at clockwise half-plain relative to 0->1 line */ 
+int ConvexApertureShape::checkOnePoint(int i0, int i1, double x, double y)
+{
+	//double res = ((convexX[i1] - convexX[i0])*(y - convexY[i0]) -(x - convexX[i0])*(convexY[i1] - convexY[i0]));
+	//std::cout<<"debug x,y="<< x <<"  "<< y <<" i0="<< i0 <<" i1="<< i1 <<"  res="<< res <<std::endl;
+	if( ((convexX[i1] - convexX[i0])*(y - convexY[i0]) - 
+		  (x - convexX[i0])*(convexY[i1] - convexY[i0])) < 0.){
+		return 1;
+	}
+	return 0;
+}
+

--- a/src/orbit/Apertures/ConvexApertureShape.hh
+++ b/src/orbit/Apertures/ConvexApertureShape.hh
@@ -1,0 +1,71 @@
+#ifndef CONVEX_APERTURE_SHAPE_H
+#define CONVEX_APERTURE_SHAPE_H
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   ConvexApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+  ConvexApertureShape is an implementation of BaseApertureShape class
+  and a collection of (x,y) points describing convex shape. User should 
+  define these points.	
+*/
+    
+class ConvexApertureShape: public BaseApertureShape
+{
+public:
+	
+	/** ConvexApertureShape constructor */
+	ConvexApertureShape();
+	
+	/** ConvexApertureShape decstructor */
+	virtual ~ConvexApertureShape();
+	
+	/** Return 1 if the particular macro-particle is inside this shape */
+	int inside(Bunch* bunch, int count);
+	
+	/** Adds the new aperture shape to the collection */ 
+	void addPoint(double x, double y);
+	
+	/** Returns vector of x-coordinates of points */ 
+	std::vector<double> getPointsX();
+	
+	/** Returns vector of y-coordinates of points */ 
+	std::vector<double> getPointsY();
+	
+	/** Removes all (x,y) points */ 
+	void removeAllPoints();
+	
+	/** Checks that we have a convex shape*/ 
+	int checkAllPoints();
+	
+	/** Checks that a point with index i that it is at clockwise half-plain relative to 0->1 line */ 
+	int checkOnePoint(int i0, int i1, int i);
+	
+	/** Checks that a point (x,y) that it is at clockwise half-plain relative to 0->1 line */ 
+	int checkOnePoint(int i0, int i1, double x, double y);
+
+protected:
+	
+	std::vector<double>  convexX;
+	std::vector<double>  convexY;
+
+};
+
+//end of COMPOSITE_APERTURE_SHAPE_H ifdef
+#endif

--- a/src/orbit/Apertures/EllipseApertureShape.cc
+++ b/src/orbit/Apertures/EllipseApertureShape.cc
@@ -1,0 +1,75 @@
+#include "EllipseApertureShape.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   EllipseApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   EllipseApertureShape is an implementation of BaseApertureShape class.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** EllipseApertureShape constructor */
+EllipseApertureShape::EllipseApertureShape(): BaseApertureShape()
+{
+		shapeName = "ellipse";
+		typeName = "ellipse";
+		x_half_axis = 0.;
+		y_half_axis = 0.;
+}
+
+/** EllipseApertureShape decstructor */
+EllipseApertureShape::~EllipseApertureShape()
+{
+}
+
+/** Return 1 if the particular macro-particle is inside this shape */
+int EllipseApertureShape::inside(Bunch* bunch, int count){
+	
+	if(x_half_axis == 0. || y_half_axis == 0.){
+		return 0;
+	}
+	
+	double** coord = bunch->coordArr();
+	
+	double x = (coord[count][0] - x_center)/x_half_axis;
+	double y = (coord[count][2] - y_center)/y_half_axis;
+	double r2 = x*x + y*y;
+	if(r2 <= 1.0){
+		return 1;
+	}
+	return 0;
+}
+
+/** Sets the half axis of ellipse in X-direction in [m] */ 
+void EllipseApertureShape::setHalfAxisX(double x_half_axis)
+{
+	this->x_half_axis = x_half_axis;
+}
+
+/** Returns the half axis of ellipse in X-direction in [m]  */ 
+double EllipseApertureShape::getHalfAxisX()
+{
+	return x_half_axis;
+}
+
+/** Sets the half axis of ellipse in Y-direction in [m] */ 
+void EllipseApertureShape::setHalfAxisY(double y_half_axis)
+{
+	this->y_half_axis = y_half_axis;
+}
+
+/** Returns the half axis of ellipse in Y-direction in [m]  */ 
+double EllipseApertureShape::getHalfAxisY()
+{
+	return y_half_axis;
+}

--- a/src/orbit/Apertures/EllipseApertureShape.hh
+++ b/src/orbit/Apertures/EllipseApertureShape.hh
@@ -1,0 +1,60 @@
+#ifndef ELLIPSE_APERTURE_SHAPE_H
+#define ELLIPSE_APERTURE_SHAPE_H
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   EllipseApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+	EllipseApertureShape is an implementation of BaseApertureShape class.
+*/
+    
+class EllipseApertureShape: public BaseApertureShape
+{
+public:
+	
+	/** EllipseApertureShape constructor */
+	EllipseApertureShape();
+	
+	/** EllipseApertureShape decstructor */
+	virtual ~EllipseApertureShape();
+	
+	/** Return 1 if the particular macro-particle is inside this shape */
+	int inside(Bunch* bunch, int count);
+	
+	/** Sets the half axis of ellipse in X-direction in [m] */ 
+	void setHalfAxisX(double x_half_axis);
+	
+	/** Returns the half axis of ellipse in X-direction in [m]  */ 
+	double getHalfAxisX();
+	
+	/** Sets the half axis of ellipse in Y-direction in [m] */ 
+	void setHalfAxisY(double y_half_axis);
+	
+	/** Returns the half axis of ellipse in Y-direction in [m]  */ 
+	double getHalfAxisY();
+	
+protected:
+	
+	double x_half_axis;
+	double y_half_axis;
+
+};
+
+//end of ELLIPSE_APERTURE_SHAPE_H ifdef
+#endif

--- a/src/orbit/Apertures/PyBaseApertureShape.cc
+++ b/src/orbit/Apertures/PyBaseApertureShape.cc
@@ -1,0 +1,55 @@
+#include "PyBaseApertureShape.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   PyBaseApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   PyBaseApertureShape is an implementation of BaseApertureShape class which 
+//   will be exposed to Python level. It uses the Python methods to calculate 
+//   the result of int PyBaseApertureShape::inside(...) method, so it is very 
+//   slow and should be used only for testing, developing prototypes etc.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** PyBaseApertureShape constructor */
+PyBaseApertureShape::PyBaseApertureShape(): BaseApertureShape()
+{
+		shapeName = "python_class_shape";
+		typeName = "python_class_shape";
+}
+
+/** PyBaseApertureShape decstructor */
+PyBaseApertureShape::~PyBaseApertureShape()
+{
+}
+
+/** Return 1 if the particular macro-particle is inside this shape */
+int PyBaseApertureShape::inside(Bunch* bunch, int count){
+	
+	double** coord = bunch->coordArr();
+	
+	PyObject* py_wrp = getPyWrapper();
+	PyObject* py_bunch = bunch->getPyWrapper();
+	
+	int res_isinside = 0;
+	
+	PyObject* py_res = PyObject_CallMethod(py_wrp,const_cast<char*>("inside"),const_cast<char*>("Oi"),py_bunch,count);
+	
+	res_isinside = (int) PyInt_AS_LONG(py_res);
+
+	Py_DECREF(py_res);
+	return res_isinside;
+}
+
+	
+

--- a/src/orbit/Apertures/PyBaseApertureShape.hh
+++ b/src/orbit/Apertures/PyBaseApertureShape.hh
@@ -1,0 +1,46 @@
+#ifndef PY_BASE_APERTURE_SHAPE_H
+#define PY_BASE_APERTURE_SHAPE_H
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   PyBaseApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+  PyBaseApertureShape is an implementation of BaseApertureShape class which 
+  will be exposed to Python level. It uses the Python methods to calculate 
+  the result of int PyBaseApertureShape::inside(...) method, so it is very 
+  slow and should be used only for testing, developing prototypes etc.tc.
+*/
+    
+class PyBaseApertureShape: public BaseApertureShape
+{
+public:
+	
+	/** PyBaseApertureShape constructor */
+	PyBaseApertureShape();
+	
+	/** PyBaseApertureShape decstructor */
+	virtual ~PyBaseApertureShape();
+	
+	/** Return 1 if the particular macro-particle is inside this shape */
+	int inside(Bunch* bunch, int count);
+
+};
+
+//end of PY_BASE_APERTURE_SHAPE_H ifdef
+#endif

--- a/src/orbit/Apertures/RectangularApertureShape.cc
+++ b/src/orbit/Apertures/RectangularApertureShape.cc
@@ -1,0 +1,74 @@
+#include "RectangularApertureShape.hh"
+
+#include <iostream>
+#include <cmath>
+#include <cfloat>
+#include <cstdlib>
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   RectangularApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+//   RectangularApertureShape is an implementation of BaseApertureShape class.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** RectangularApertureShape constructor */
+RectangularApertureShape::RectangularApertureShape(): BaseApertureShape()
+{
+		shapeName = "rectangular";
+		typeName = "rectangular";
+		x_half_size = 0.;
+		y_half_size = 0.;
+}
+
+/** RectangularApertureShape decstructor */
+RectangularApertureShape::~RectangularApertureShape()
+{
+}
+
+/** Return 1 if the particular macro-particle is inside this shape */
+int RectangularApertureShape::inside(Bunch* bunch, int count){
+	
+	if(x_half_size == 0. || y_half_size == 0.){
+		return 0;
+	}
+	
+	double** coord = bunch->coordArr();
+	
+	double x = fabs((coord[count][0] - x_center));
+	double y = fabs((coord[count][2] - y_center));
+	if(x <= x_half_size && y < y_half_size){
+		return 1;
+	}
+	return 0;
+}
+
+/** Sets the half size in X-direction in [m] */ 
+void RectangularApertureShape::setHalfX(double x_half_size)
+{
+	this->x_half_size = x_half_size;
+}
+
+/** Returns the half size in X-direction in [m]  */ 
+double RectangularApertureShape::getHalfX()
+{
+	return x_half_size;
+}
+
+/** Sets the half size in Y-direction in [m] */ 
+void RectangularApertureShape::setHalfY(double y_half_size)
+{
+	this->y_half_size = y_half_size;
+}
+
+/** Returns the half size in Y-direction in [m]  */ 
+double RectangularApertureShape::getHalfY()
+{
+	return y_half_size;
+}

--- a/src/orbit/Apertures/RectangularApertureShape.hh
+++ b/src/orbit/Apertures/RectangularApertureShape.hh
@@ -1,0 +1,60 @@
+#ifndef RECTANGULAR_APERTURE_SHAPE_H
+#define RECTANGULAR_APERTURE_SHAPE_H
+
+//pyORBIT utils
+#include "CppPyWrapper.hh"
+
+#include "Bunch.hh"
+#include "BaseApertureShape.hh"
+
+using namespace std;
+
+///////////////////////////////////////////////////////////////////////////
+//
+// NAME
+//
+//   RectangularApertureShape
+//
+// AUTHOR: 
+//   Andrei Shishlo October 2022
+//
+///////////////////////////////////////////////////////////////////////////
+
+/** 
+	RectangularApertureShape is an implementation of BaseApertureShape class.
+*/
+    
+class RectangularApertureShape: public BaseApertureShape
+{
+public:
+	
+	/** RectangularApertureShape constructor */
+	RectangularApertureShape();
+	
+	/** RectangularApertureShape decstructor */
+	virtual ~RectangularApertureShape();
+	
+	/** Return 1 if the particular macro-particle is inside this shape */
+	int inside(Bunch* bunch, int count);
+	
+	/** Sets the half size in X-direction in [m] */ 
+	void setHalfX(double x_half_size);
+	
+	/** Returns the half size in X-direction in [m]  */ 
+	double getHalfX();
+	
+	/** Sets the half size in Y-direction in [m] */ 
+	void setHalfY(double y_half_size);
+	
+	/** Returns the half size in Y-direction in [m]  */ 
+	double getHalfY();
+	
+protected:
+	
+	double x_half_size;
+	double y_half_size;
+
+};
+
+//end of RECTANGULAR_APERTURE_SHAPE_H ifdef
+#endif

--- a/src/orbit/Apertures/wrap_BaseAperture.cc
+++ b/src/orbit/Apertures/wrap_BaseAperture.cc
@@ -52,7 +52,7 @@ extern "C" {
 	  	Py_INCREF(Py_None);
 	  	return Py_None;
 	  }
-	  PyObject* pyBaseApertureShape = cpp_BaseAperture->getPyWrapper();
+	  PyObject* pyBaseApertureShape = baseApertureShape->getPyWrapper();
 		Py_INCREF(pyBaseApertureShape);
 		return pyBaseApertureShape;	  
 	}	

--- a/src/orbit/Apertures/wrap_BaseAperture.cc
+++ b/src/orbit/Apertures/wrap_BaseAperture.cc
@@ -1,0 +1,235 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "BaseAperture.hh"
+#include "BaseApertureShape.hh"
+
+namespace wrap_base_aperture{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ BaseAperture instance.
+      It never will be called directly.
+	*/
+	static PyObject* BaseAperture_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int BaseAperture_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){  	
+	  self->cpp_obj =  new BaseAperture();
+	  ((BaseAperture*) self->cpp_obj)->setPyWrapper((PyObject*) self);
+    return 0;
+  }
+  
+  /** Sets the pyBaseApertureShape object for inside(...) method */
+  static PyObject* BaseAperture_setApertureShape(PyObject *self, PyObject *args){
+	  BaseAperture* cpp_BaseAperture = (BaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+	  PyObject* pyBaseApertureShape;
+		if(!PyArg_ParseTuple(args,"O:setApertureShape",&pyBaseApertureShape)){
+				ORBIT_MPI_Finalize("BaseAperture - setApertureShape(BaseApertureShape) - parameter is needed. Stop.");
+		}
+		cpp_BaseAperture->setApertureShape((BaseApertureShape*) ((pyORBIT_Object*) pyBaseApertureShape)->cpp_obj);
+		Py_INCREF(Py_None);
+		return Py_None;	  
+	}
+	
+  /** Returns the pyBaseApertureShape object for inside(...) method */
+  static PyObject* BaseAperture_getApertureShape(PyObject *self, PyObject *args){
+	  BaseAperture* cpp_BaseAperture = (BaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+	  BaseApertureShape* baseApertureShape = cpp_BaseAperture->getApertureShape();
+	  if(baseApertureShape == NULL){
+	  	Py_INCREF(Py_None);
+	  	return Py_None;
+	  }
+	  PyObject* pyBaseApertureShape = cpp_BaseAperture->getPyWrapper();
+		Py_INCREF(pyBaseApertureShape);
+		return pyBaseApertureShape;	  
+	}	
+  
+  /** Performs the collimation tracking of the bunch */
+  static PyObject* BaseAperture_checkBunch(PyObject *self, PyObject *args){
+	  BaseAperture* cpp_BaseAperture = (BaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		PyObject* pyBunch;
+		PyObject* pyLostBunch;
+		int nVars = PyTuple_Size(args);
+		if(nVars == 2){
+			if(!PyArg_ParseTuple(args,"OO:checkBunch",&pyBunch, &pyLostBunch)){
+				ORBIT_MPI_Finalize("BaseAperture - checkBunch(Bunch* bunch, Bunch* lostbunch) - parameters are needed. Stop.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type) || !PyObject_IsInstance(pyLostBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("BaseAperture - checkBunch(Bunch* bunch, Bunch* lostbunch) - method needs a Bunch. Stop.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			Bunch* cpp_lostbunch = (Bunch*) ((pyORBIT_Object*)pyLostBunch)->cpp_obj;
+			cpp_BaseAperture->checkBunch(cpp_bunch, cpp_lostbunch);
+		}
+		else{
+			if(!PyArg_ParseTuple(args,"O:checkBunch",&pyBunch)){
+				ORBIT_MPI_Finalize("BaseAperture - checkBunch(Bunch* bunch) - parameter is needed. Stop.");
+			}
+			PyObject* pyORBIT_Bunch_Type = wrap_orbit_bunch::getBunchType("Bunch");
+			if(!PyObject_IsInstance(pyBunch,pyORBIT_Bunch_Type)){
+				ORBIT_MPI_Finalize("BaseAperture - checkBunch(Bunch* bunch) - method needs a Bunch. Stop.");
+			}
+			Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object*)pyBunch)->cpp_obj;
+			cpp_BaseAperture->checkBunch(cpp_bunch, NULL);			
+		}
+		Py_INCREF(Py_None);
+		return Py_None;
+  }
+  
+	// name([name]) - sets or returns the name of the aperture
+  static PyObject* BaseAperture_name(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyBaseAperture= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyBaseAperture->cpp_obj;		
+    const char* name = NULL;
+    if(!PyArg_ParseTuple(	args,"|s:name",&name)){
+      ORBIT_MPI_Finalize("BaseAperture.name(...) - call should be - name([name]). Stop.");
+    }
+		if(name != NULL){
+      std::string name_str(name);
+      cpp_BaseApertureShape->setName(name_str);
+		}
+		return Py_BuildValue("s",cpp_BaseApertureShape->getName().c_str());
+  }  
+		
+	/** Sets/Returns the position of the element in the lattice */
+	static PyObject* BaseAperture_position(PyObject *self, PyObject *args){
+		BaseAperture* cpp_BaseAperture = (BaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		double position = 0;
+		int nVars = PyTuple_Size(args);
+		if(nVars == 1){
+			if(!PyArg_ParseTuple(	args,"d:arguments",&position)){
+				ORBIT_MPI_Finalize("BaseAperture - setPosition - cannot parse arguments! It should be (position). Stop.");
+			}
+			cpp_BaseAperture->setPosition(position);
+		}
+		position = cpp_BaseAperture->getPosition();
+		return Py_BuildValue("d",position);
+	}
+	
+	/** Returns the number of lost particles at this aperture across all CPUs */
+	static PyObject* BaseAperture_getNumberOfLost(PyObject *self, PyObject *args){
+		BaseAperture* cpp_BaseAperture = (BaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		int nLostParts = cpp_BaseAperture->getNumberOfLost();
+		return Py_BuildValue("i",nLostParts);
+	}	
+	
+	/** Sets or returns the aperture state 1 - is active, 0 - switched off*/
+	static PyObject* BaseAperture_setOnOff(PyObject *self, PyObject *args){
+		BaseAperture* cpp_BaseAperture = (BaseAperture*)((pyORBIT_Object*) self)->cpp_obj;
+		int nVars = PyTuple_Size(args);
+		int isActive = 1;
+		if(nVars == 1){
+			if(!PyArg_ParseTuple(	args,"i:onOff",&isActive)){
+				ORBIT_MPI_Finalize("BaseAperture.onOff(isActive)  - cannot parse arguments! Stop.");
+			}
+			if(isActive != 1 && isActive != 0){
+				ORBIT_MPI_Finalize("BaseAperture.onOff(isActive)  - isActive should be 1 or 0! Stop.");
+			}
+			cpp_BaseAperture->setOnOff(isActive);
+		}
+		isActive = cpp_BaseAperture->getOnOff();
+		return Py_BuildValue("b",isActive);	
+	}	
+	
+	
+  //-----------------------------------------------------
+  //destructor for python BaseAperture class (__del__ method).
+  //-----------------------------------------------------
+  static void BaseAperture_del(pyORBIT_Object* self){
+		//std::cerr<<"The BaseAperture __del__ has been called!"<<std::endl;
+		delete ((BaseAperture*)self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python BaseAperture wrapper class
+	// they will be vailable from python level
+	static PyMethodDef BaseApertureClassMethods[] = {
+		{ "setApertureShape", BaseAperture_setApertureShape, METH_VARARGS,"Sets the pyBaseApertureShape object for inside(...) method."},
+		{ "getApertureShape", BaseAperture_getApertureShape, METH_VARARGS,"Returns the pyBaseApertureShape object for inside(...) method."},
+		{ "checkBunch",				BaseAperture_checkBunch,       METH_VARARGS,"Performs the aperture check of the bunch."},
+		{ "name",             BaseAperture_name,             METH_VARARGS,"Sets or returns the name of the aperture."},
+		{ "position",			    BaseAperture_position,         METH_VARARGS,"Sets/Returns the position of the element in the lattice."},
+		{ "getNumberOfLost",  BaseAperture_getNumberOfLost,  METH_VARARGS,"Returns the number of lost particles at this aperture across all CPUs."},
+		{ "onOff",            BaseAperture_setOnOff,         METH_VARARGS,"Sets/Returns the state of aperture 0 or 1."},
+   {NULL}
+  };
+
+	static PyMemberDef BaseApertureClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python BaseAperture wrapper type definition
+	static PyTypeObject pyORBIT_BaseAperture_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"BaseAperture", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) BaseAperture_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The BaseAperture python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		BaseApertureClassMethods, /* tp_methods */
+		BaseApertureClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) BaseAperture_init, /* tp_init */
+		0, /* tp_alloc */
+		BaseAperture_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization BaseAperture class
+	//--------------------------------------------------
+
+	void initBaseAperture(PyObject* module){
+		//check that the BaseAperture wrapper is ready
+		if (PyType_Ready(&pyORBIT_BaseAperture_Type) < 0) return;
+		Py_INCREF(&pyORBIT_BaseAperture_Type);
+		PyModule_AddObject(module, "BaseAperture", (PyObject *)&pyORBIT_BaseAperture_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_BaseAperture.hh
+++ b/src/orbit/Apertures/wrap_BaseAperture.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_BASE_APERTURE_HH_
+#define WRAP_ORBIT_BASE_APERTURE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_base_aperture{
+    void initBaseAperture(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_BASE_APERTURE_HH_*/

--- a/src/orbit/Apertures/wrap_CompositeApertureShape.cc
+++ b/src/orbit/Apertures/wrap_CompositeApertureShape.cc
@@ -1,0 +1,171 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "CompositeApertureShape.hh"
+
+namespace wrap_py_composite_aperture_shape{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ Circle, Ellipse, and Rectangular ApertureShape instances.
+	*/
+	static PyObject* CompositeApertureShape_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int CompositeApertureShape_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
+  	self->cpp_obj = (pyORBIT_Object*) new CompositeApertureShape();
+	  ((BaseApertureShape*) self->cpp_obj)->setPyWrapper((PyObject*) self);	  
+    return 0;
+  }
+
+	// name([name]) - sets or returns the name of the shape 
+  static PyObject* CompositeApertureShape_name(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyCompositeApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyCompositeApertureShape->cpp_obj;		
+    const char* name = NULL;
+    if(!PyArg_ParseTuple(	args,"|s:name",&name)){
+      ORBIT_MPI_Finalize("CompositeApertureShape.name(...) - call should be - name([name]). Stop.");
+    }
+		if(name != NULL){
+      std::string name_str(name);
+      cpp_BaseApertureShape->setName(name_str);
+		}
+		return Py_BuildValue("s",cpp_BaseApertureShape->getName().c_str());
+  }
+  
+	// typeName() - returns the type name of the shape 
+  static PyObject* CompositeApertureShape_typeName(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyCompositeApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyCompositeApertureShape->cpp_obj;
+		int nVars = PyTuple_Size(args);
+		if(nVars != 0){
+			ORBIT_MPI_Finalize("CompositeApertureShape.typeName() - has no parameters. Stop.");
+    }
+		return Py_BuildValue("s",cpp_BaseApertureShape->getTypeName().c_str());
+  }  
+  
+	// addApertureShape() - adds the ApertureShape instance to composite
+  static PyObject* CompositeApertureShape_addApertureShape(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyCompositeApertureShape= (pyORBIT_Object*) self;
+		CompositeApertureShape* cpp_CompositeApertureShape = (CompositeApertureShape*) pyCompositeApertureShape->cpp_obj;
+	  PyObject* pyBaseApertureShape;
+		if(!PyArg_ParseTuple(args,"O:setApertureShape",&pyBaseApertureShape)){
+				ORBIT_MPI_Finalize("CompositeApertureShape.addApertureShape(BaseApertureShape) - parameter is needed. Stop.");
+		}
+		cpp_CompositeApertureShape->addApertureShape((BaseApertureShape*) ((pyORBIT_Object*) pyBaseApertureShape)->cpp_obj);
+		Py_INCREF(Py_None);
+		return Py_None;
+  }
+  
+	// getApertureShapes() - returns the ApertureShape instances inside the composite
+  static PyObject* CompositeApertureShape_getApertureShapes(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyCompositeApertureShape= (pyORBIT_Object*) self;
+		CompositeApertureShape* cpp_CompositeApertureShape = (CompositeApertureShape*) pyCompositeApertureShape->cpp_obj;
+		std::vector<BaseApertureShape*> apertureShapes = cpp_CompositeApertureShape->getApertureShape();
+		//create tuple with apertureShapes
+		PyObject* resTuple = PyTuple_New(apertureShapes.size());
+		for(int i = 0, n = apertureShapes.size(); i < n; i++){
+			PyObject* py_nm = apertureShapes[i]->getPyWrapper();
+			if(PyTuple_SetItem(resTuple,i,py_nm)){
+				ORBIT_MPI_Finalize("CompositeApertureShape.getApertureShapes(...) - cannot add the ApertureShape instance to composite");
+			}
+		}
+    return resTuple;
+  }   
+
+  //-----------------------------------------------------
+  //destructor for python CompositeApertureShape class (__del__ method).
+  //-----------------------------------------------------
+  static void CompositeApertureShape_del(pyORBIT_Object* self){
+		//std::cerr<<"debug CompositeApertureShape __del__ has been called!"<<std::endl;
+		delete ((BaseApertureShape*)self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python CompositeApertureShape wrapper class
+	// they will be vailable from python level
+	static PyMethodDef CompositeApertureShapeClassMethods[] = {
+		{ "name",                 CompositeApertureShape_name,            METH_VARARGS,"Sets or returns the name of the shape."},
+		{ "typeName",             CompositeApertureShape_typeName,        METH_VARARGS,"Returns the type of the shape."},
+		{ "addApertureShape",     CompositeApertureShape_addApertureShape,METH_VARARGS,"Adds the ApertureShape instance to composit."},
+		{ "getApertureShapes", CompositeApertureShape_getApertureShapes,  METH_VARARGS,"Returns tuple of ApertureShape instances."},
+		{NULL}
+  };
+
+	static PyMemberDef CompositeApertureShapeClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python CompositeApertureShape wrapper type definition
+	static PyTypeObject pyORBIT_CompositeApertureShape_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"CompositeApertureShape", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) CompositeApertureShape_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The CompositeApertureShape python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		CompositeApertureShapeClassMethods, /* tp_methods */
+		CompositeApertureShapeClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) CompositeApertureShape_init, /* tp_init */
+		0, /* tp_alloc */
+		CompositeApertureShape_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization CompositeApertureShape class
+	//--------------------------------------------------
+
+	void initCompositeApertureShape(PyObject* module){
+		//check that the CompositeApertureShape wrapper is ready
+		if (PyType_Ready(&pyORBIT_CompositeApertureShape_Type) < 0) return;
+		Py_INCREF(&pyORBIT_CompositeApertureShape_Type);
+		PyModule_AddObject(module, "CompositeApertureShape", (PyObject *)&pyORBIT_CompositeApertureShape_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_CompositeApertureShape.hh
+++ b/src/orbit/Apertures/wrap_CompositeApertureShape.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_COMPOSITE_APERTURE_SHAPE_HH_
+#define WRAP_ORBIT_COMPOSITE_APERTURE_SHAPE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_py_composite_aperture_shape{
+    void initCompositeApertureShape(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_COMPOSITE_APERTURE_SHAPE_HH_*/

--- a/src/orbit/Apertures/wrap_ConvexApertureShape.cc
+++ b/src/orbit/Apertures/wrap_ConvexApertureShape.cc
@@ -1,0 +1,215 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "ConvexApertureShape.hh"
+
+namespace wrap_convex_aperture_shape{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ Circle, Ellipse, and Rectangular ApertureShape instances.
+	*/
+	static PyObject* ConvexApertureShape_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int ConvexApertureShape_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
+  	self->cpp_obj = new ConvexApertureShape();
+ 	  ((BaseApertureShape*) self->cpp_obj)->setPyWrapper((PyObject*) self);	  
+    return 0;
+  }
+
+	// Sets or returns the center of the shape in X-direction 
+  static PyObject* ConvexApertureShape_centerX(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyConvexApertureShape = (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyConvexApertureShape->cpp_obj;	
+		int nVars = PyTuple_Size(args);
+		if(nVars >= 1){
+			double center = 0.;
+			if(!PyArg_ParseTuple(	args,"d:centerX",&center)){
+				ORBIT_MPI_Finalize("ConvexApertureShape.centerX(...) - call should be - centerX([center]). Stop.");
+			}
+			cpp_BaseApertureShape->setCenterX(center);
+    }
+		return Py_BuildValue("d",cpp_BaseApertureShape->getCenterX());
+  }
+  
+	// Sets or returns the center of the shape in Y-direction 
+  static PyObject* ConvexApertureShape_centerY(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyConvexApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyConvexApertureShape->cpp_obj;	
+		int nVars = PyTuple_Size(args);
+		if(nVars >= 1){
+			double center = 0.;
+			if(!PyArg_ParseTuple(	args,"d:centerY",&center)){
+				ORBIT_MPI_Finalize("ConvexApertureShape.centerY(...) - call should be - centerY([center]). Stop.");
+			}
+			cpp_BaseApertureShape->setCenterY(center);
+    }
+		return Py_BuildValue("d",cpp_BaseApertureShape->getCenterY());
+  }	  
+
+	// name([name]) - sets or returns the name of the shape 
+  static PyObject* ConvexApertureShape_name(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyConvexApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyConvexApertureShape->cpp_obj;		
+    const char* name = NULL;
+    if(!PyArg_ParseTuple(	args,"|s:name",&name)){
+      ORBIT_MPI_Finalize("ConvexApertureShape.name(...) - call should be - name([name]). Stop.");
+    }
+		if(name != NULL){
+      std::string name_str(name);
+      cpp_BaseApertureShape->setName(name_str);
+		}
+		return Py_BuildValue("s",cpp_BaseApertureShape->getName().c_str());
+  }
+  
+	// typeName() - returns the type name of the shape 
+  static PyObject* ConvexApertureShape_typeName(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyConvexApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyConvexApertureShape->cpp_obj;
+		int nVars = PyTuple_Size(args);
+		if(nVars != 0){
+			ORBIT_MPI_Finalize("ConvexApertureShape.typeName() - has no parameters. Stop.");
+    }
+		return Py_BuildValue("s",cpp_BaseApertureShape->getTypeName().c_str());
+  }  
+  
+	// Sets the convex shape points 
+  static PyObject* ConvexApertureShape_setPoints(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyConvexApertureShape= (pyORBIT_Object*) self;
+		ConvexApertureShape* cpp_ConvexApertureShape = (ConvexApertureShape*) pyConvexApertureShape->cpp_obj;
+		PyObject* pyPointList = NULL;
+  	if(!PyArg_ParseTuple( args,"O:points",&pyPointList)){
+  		ORBIT_MPI_Finalize("ConvexApertureShape.setPoints([[x,y],...] - no right parameters. Stop.");
+  	}
+  	if(!PyList_CheckExact(pyPointList)){
+  		ORBIT_MPI_Finalize("ConvexApertureShape.setPoints([[x,y],...] - no right parameters. Stop.");
+  	}
+  	cpp_ConvexApertureShape->removeAllPoints();
+  	int nPoints = PyList_Size(pyPointList);
+  	for(int ind = 0; ind < nPoints; ind++){
+  		PyObject* pXY_List = PyList_GetItem(pyPointList,ind);
+  		double x = PyFloat_AS_DOUBLE(PyList_GetItem(pXY_List,0));
+  		double y = PyFloat_AS_DOUBLE(PyList_GetItem(pXY_List,1));
+  		cpp_ConvexApertureShape->addPoint(x,y);	
+  	}
+		cpp_ConvexApertureShape->checkAllPoints();
+    Py_INCREF(Py_None);
+		return Py_None;		
+  }
+
+	// Returns the convex shape points as array [[x,y],...]
+  static PyObject* ConvexApertureShape_getPoints(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyConvexApertureShape= (pyORBIT_Object*) self;
+		ConvexApertureShape* cpp_ConvexApertureShape = (ConvexApertureShape*) pyConvexApertureShape->cpp_obj;
+		int nPoints = cpp_ConvexApertureShape->getPointsX().size();
+		PyObject* pyPointList = PyList_New(nPoints);
+		for(int ind = 0; ind < nPoints; ind++){
+			double x = cpp_ConvexApertureShape->getPointsX()[ind];
+			double y = cpp_ConvexApertureShape->getPointsY()[ind];
+			PyObject* pyXY_List = PyList_New(2);
+			PyList_SET_ITEM(pyXY_List,0,PyFloat_FromDouble(x));
+			PyList_SET_ITEM(pyXY_List,1,PyFloat_FromDouble(y));
+			PyList_SET_ITEM(pyPointList,ind,pyXY_List);
+		}
+    Py_INCREF(pyPointList);
+		return pyPointList;		
+  }  
+
+  //-----------------------------------------------------
+  //destructor for python ConvexApertureShape class (__del__ method).
+  //-----------------------------------------------------
+  static void ConvexApertureShape_del(pyORBIT_Object* self){
+		delete ((ConvexApertureShape*) self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python ConvexApertureShape wrapper class
+	// they will be vailable from python level
+	static PyMethodDef ConvexApertureShapeClassMethods[] = {
+		{ "centerX",  ConvexApertureShape_centerX,  METH_VARARGS,"Sets or returns the X-shift of the shape center."},	
+		{ "centerY",  ConvexApertureShape_centerY,  METH_VARARGS,"Sets or returns the Y-shift of the shape center."},	
+		{ "name",     ConvexApertureShape_name,     METH_VARARGS,"Sets or returns the name of the shape."},
+		{ "typeName", ConvexApertureShape_typeName, METH_VARARGS,"Returns the type of the shape."},
+		{ "setPoints",ConvexApertureShape_setPoints,METH_VARARGS,"Sets the convex shape points as [[x,y],...]"},
+		{ "getPoints",ConvexApertureShape_getPoints,METH_VARARGS,"Returns the convex shape points as [[x,y],...]"},
+		{NULL}
+  };
+
+	static PyMemberDef ConvexApertureShapeClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python ConvexApertureShape wrapper type definition
+	static PyTypeObject pyORBIT_ConvexApertureShape_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"ConvexApertureShape", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) ConvexApertureShape_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The ConvexApertureShape python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		ConvexApertureShapeClassMethods, /* tp_methods */
+		ConvexApertureShapeClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) ConvexApertureShape_init, /* tp_init */
+		0, /* tp_alloc */
+		ConvexApertureShape_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization ConvexApertureShape class
+	//--------------------------------------------------
+
+	void initConvexApertureShape(PyObject* module){
+		//check that the ConvexApertureShape wrapper is ready
+		if (PyType_Ready(&pyORBIT_ConvexApertureShape_Type) < 0) return;
+		Py_INCREF(&pyORBIT_ConvexApertureShape_Type);
+		PyModule_AddObject(module, "ConvexApertureShape", (PyObject *)&pyORBIT_ConvexApertureShape_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_ConvexApertureShape.hh
+++ b/src/orbit/Apertures/wrap_ConvexApertureShape.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_CONVEX_APERTURE_SHAPE_HH_
+#define WRAP_ORBIT_CONVEX_APERTURE_SHAPE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_convex_aperture_shape{
+    void initConvexApertureShape(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_CONVEX_APERTURE_SHAPE_HH_*/

--- a/src/orbit/Apertures/wrap_PrimitiveApertureShape.cc
+++ b/src/orbit/Apertures/wrap_PrimitiveApertureShape.cc
@@ -1,0 +1,282 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "CircleApertureShape.hh"
+#include "EllipseApertureShape.hh"
+#include "RectangularApertureShape.hh"
+
+namespace wrap_py_base_aperture_shape{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ Circle, Ellipse, and Rectangular ApertureShape instances.
+	*/
+	static PyObject* PrimitiveApertureShape_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int PrimitiveApertureShape_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
+  	const char* name = NULL;
+  	double param1 =  0.0;
+  	double param2 = -1.0;
+  	if(!PyArg_ParseTuple(	args,"sd|d:parameters",&name,&param1,&param2)){
+  		ORBIT_MPI_Finalize("PrimitiveApertureShape(shapeType, par1[,par2]) - no right parameters. Stop.");
+  	}
+  	std::string typeName(name);
+  	self->cpp_obj = NULL;
+  	if(typeName == "circle"){
+  		self->cpp_obj =  new CircleApertureShape();
+  		((CircleApertureShape*) self->cpp_obj)->setRadius(param1);
+  	} 
+  	if(typeName == "ellipse"){
+  		self->cpp_obj =  new EllipseApertureShape();
+  		if(param2 < 0.){
+  			ORBIT_MPI_Finalize("PrimitiveApertureShape(ellipse, par1,par2) - par2 is not there or < 0. Stop.");
+  		}
+  		((EllipseApertureShape*) self->cpp_obj)->setHalfAxisX(param1);
+  		((EllipseApertureShape*) self->cpp_obj)->setHalfAxisY(param2);
+  	}   	
+  	if(typeName == "rectangular"){
+  		self->cpp_obj =  new RectangularApertureShape();
+  		if(param2 < 0.){
+  			ORBIT_MPI_Finalize("PrimitiveApertureShape(rectangular, par1,par2) - par2 is not there or < 0. Stop.");
+  		}
+  		((RectangularApertureShape*) self->cpp_obj)->setHalfX(param1);
+  		((RectangularApertureShape*) self->cpp_obj)->setHalfY(param2);  		
+  	}   	
+  	if(self->cpp_obj == NULL){
+  		ORBIT_MPI_Finalize("PrimitiveApertureShape(shapeType, par1[,par2]) - shapeType should be circle,ellipse, or rectangular. Stop.");
+  	}
+	  ((BaseApertureShape*) self->cpp_obj)->setPyWrapper((PyObject*) self);	  
+    return 0;
+  }
+
+	// Sets or returns the center of the shape in X-direction 
+  static PyObject* PrimitiveApertureShape_centerX(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPrimitiveApertureShape = (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyPrimitiveApertureShape->cpp_obj;	
+		int nVars = PyTuple_Size(args);
+		if(nVars >= 1){
+			double center = 0.;
+			if(!PyArg_ParseTuple(	args,"d:centerX",&center)){
+				ORBIT_MPI_Finalize("PrimitiveApertureShape.centerX(...) - call should be - centerX([center]). Stop.");
+			}
+			cpp_BaseApertureShape->setCenterX(center);
+    }
+		return Py_BuildValue("d",cpp_BaseApertureShape->getCenterX());
+  }
+  
+	// Sets or returns the center of the shape in Y-direction 
+  static PyObject* PrimitiveApertureShape_centerY(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPrimitiveApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyPrimitiveApertureShape->cpp_obj;	
+		int nVars = PyTuple_Size(args);
+		if(nVars >= 1){
+			double center = 0.;
+			if(!PyArg_ParseTuple(	args,"d:centerY",&center)){
+				ORBIT_MPI_Finalize("PrimitiveApertureShape.centerY(...) - call should be - centerY([center]). Stop.");
+			}
+			cpp_BaseApertureShape->setCenterY(center);
+    }
+		return Py_BuildValue("d",cpp_BaseApertureShape->getCenterY());
+  }	  
+
+	// name([name]) - sets or returns the name of the shape 
+  static PyObject* PrimitiveApertureShape_name(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPrimitiveApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyPrimitiveApertureShape->cpp_obj;		
+    const char* name = NULL;
+    if(!PyArg_ParseTuple(	args,"|s:name",&name)){
+      ORBIT_MPI_Finalize("PrimitiveApertureShape.name(...) - call should be - name([name]). Stop.");
+    }
+		if(name != NULL){
+      std::string name_str(name);
+      cpp_BaseApertureShape->setName(name_str);
+		}
+		return Py_BuildValue("s",cpp_BaseApertureShape->getName().c_str());
+  }
+  
+	// typeName() - returns the type name of the shape 
+  static PyObject* PrimitiveApertureShape_typeName(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPrimitiveApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyPrimitiveApertureShape->cpp_obj;
+		int nVars = PyTuple_Size(args);
+		if(nVars != 0){
+			ORBIT_MPI_Finalize("PrimitiveApertureShape.typeName() - has no parameters. Stop.");
+    }
+		return Py_BuildValue("s",cpp_BaseApertureShape->getTypeName().c_str());
+  }  
+  
+	// Returns the parameters of the shape like radius of the circle 
+  static PyObject* PrimitiveApertureShape_getParamsDict(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPrimitiveApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyPrimitiveApertureShape->cpp_obj;	
+		PyObject* paramsDict = PyDict_New();
+		std::string typeName = cpp_BaseApertureShape->getTypeName();
+		double param1 =  0.0;
+		double param2 = -1.0;
+  	if(typeName == "circle"){
+  		param1 = ((CircleApertureShape*) cpp_BaseApertureShape)->getRadius();
+  		PyObject* pyRadius = Py_BuildValue("d",param1);
+  		PyDict_SetItemString(paramsDict,"radius",pyRadius);
+  		Py_DECREF(pyRadius);
+  	} 
+  	if(typeName == "ellipse"){
+  		param1 = ((EllipseApertureShape*) cpp_BaseApertureShape)->getHalfAxisX();
+  		param2 = ((EllipseApertureShape*) cpp_BaseApertureShape)->getHalfAxisY();
+  		PyObject* pyHalfX = Py_BuildValue("d",param1);
+  		PyDict_SetItemString(paramsDict,"halfAxisX",pyHalfX);
+  		Py_DECREF(pyHalfX);
+  		PyObject* pyHalfY = Py_BuildValue("d",param2);
+  		PyDict_SetItemString(paramsDict,"halfAxisY",pyHalfY);
+  		Py_DECREF(pyHalfY);
+  	}   	
+  	if(typeName == "rectangular"){
+  		param1 = ((RectangularApertureShape*) cpp_BaseApertureShape)->getHalfX();
+  		param2 = ((RectangularApertureShape*) cpp_BaseApertureShape)->getHalfY();
+  		PyObject* pyHalfX = Py_BuildValue("d",param1);
+  		PyDict_SetItemString(paramsDict,"halfSizeX",pyHalfX);
+  		Py_DECREF(pyHalfX);
+  		PyObject* pyHalfY = Py_BuildValue("d",param2);
+  		PyDict_SetItemString(paramsDict,"halfSizeY",pyHalfY);
+  		Py_DECREF(pyHalfY);  		
+  	}
+		return paramsDict;
+  }
+
+	// Sets the parameters of the shape like radius of the circle etc.
+  static PyObject* PrimitiveApertureShape_setParams(PyObject *self, PyObject *args){
+  	double param1 =  0.0;
+  	double param2 = -1.0;
+  	if(!PyArg_ParseTuple(	args,"d|d:parameters",&param1,&param2)){
+  		ORBIT_MPI_Finalize("PrimitiveApertureShape.setParams(par1[,par2]) - no right parameters. Stop.");
+  	}
+    pyORBIT_Object* pyPrimitiveApertureShape= (pyORBIT_Object*) self;
+		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyPrimitiveApertureShape->cpp_obj;	  	
+  	std::string typeName = cpp_BaseApertureShape->getTypeName();
+  	int settings_done = 0;
+  	std::cout << "debug PrimitiveApertureShape_setParams 1 "<<std::endl;
+  	if(typeName == "circle"){
+  		((CircleApertureShape*) cpp_BaseApertureShape)->setRadius(param1);
+  		settings_done = 1;
+  	} 
+  	if(typeName == "ellipse"){
+  		if(param2 < 0.){
+  			ORBIT_MPI_Finalize("ellipse PrimitiveApertureShape.setParams(par1,par2) - par2 is not there or < 0. Stop.");
+  		}
+  		((EllipseApertureShape*) cpp_BaseApertureShape)->setHalfAxisX(param1);
+  		((EllipseApertureShape*) cpp_BaseApertureShape)->setHalfAxisY(param2);
+  		settings_done = 1;
+  	}   	
+  	if(typeName == "rectangular"){
+  		if(param2 < 0.){
+  			ORBIT_MPI_Finalize("rectangular PrimitiveApertureShape.setParams(par1,par2) - par2 is not there or < 0. Stop.");
+  		}
+  		((RectangularApertureShape*) cpp_BaseApertureShape)->setHalfX(param1);
+  		((RectangularApertureShape*) cpp_BaseApertureShape)->setHalfY(param2);
+  		settings_done = 1;
+  	}
+  	if(settings_done != 1){
+  		ORBIT_MPI_Finalize("PrimitiveApertureShape.setParams(par1,par2) - shape does not defined. Stop.");
+  	}
+    Py_INCREF(Py_None);
+		return Py_None;
+  }
+
+  //-----------------------------------------------------
+  //destructor for python PrimitiveApertureShape class (__del__ method).
+  //-----------------------------------------------------
+  static void PrimitiveApertureShape_del(pyORBIT_Object* self){
+		//std::cerr<<"debug PrimitiveApertureShape __del__ has been called!"<<std::endl;
+		delete ((BaseApertureShape*)self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python PrimitiveApertureShape wrapper class
+	// they will be vailable from python level
+	static PyMethodDef PrimitiveApertureShapeClassMethods[] = {
+		{ "centerX",      PrimitiveApertureShape_centerX,      METH_VARARGS,"Sets or returns the X-shift of the shape center."},	
+		{ "centerY",      PrimitiveApertureShape_centerY,      METH_VARARGS,"Sets or returns the Y-shift of the shape center."},	
+		{ "name",         PrimitiveApertureShape_name,         METH_VARARGS,"Sets or returns the name of the shape."},
+		{ "typeName",     PrimitiveApertureShape_typeName,     METH_VARARGS,"Returns the type of the shape."},
+		{ "getParamsDict",PrimitiveApertureShape_getParamsDict,METH_VARARGS,"Returns params. dict. like radius of the circle."},
+		{ "setParams",    PrimitiveApertureShape_setParams,    METH_VARARGS,"Sets params. like radius of the circle, or ellipse half axes."},
+		{NULL}
+  };
+
+	static PyMemberDef PrimitiveApertureShapeClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python PrimitiveApertureShape wrapper type definition
+	static PyTypeObject pyORBIT_PrimitiveApertureShape_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"PrimitiveApertureShape", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) PrimitiveApertureShape_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The PrimitiveApertureShape python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		PrimitiveApertureShapeClassMethods, /* tp_methods */
+		PrimitiveApertureShapeClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) PrimitiveApertureShape_init, /* tp_init */
+		0, /* tp_alloc */
+		PrimitiveApertureShape_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization PrimitiveApertureShape class
+	//--------------------------------------------------
+
+	void initPrimitiveApertureShape(PyObject* module){
+		//check that the PrimitiveApertureShape wrapper is ready
+		if (PyType_Ready(&pyORBIT_PrimitiveApertureShape_Type) < 0) return;
+		Py_INCREF(&pyORBIT_PrimitiveApertureShape_Type);
+		PyModule_AddObject(module, "PrimitiveApertureShape", (PyObject *)&pyORBIT_PrimitiveApertureShape_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_PrimitiveApertureShape.cc
+++ b/src/orbit/Apertures/wrap_PrimitiveApertureShape.cc
@@ -166,7 +166,6 @@ extern "C" {
 		BaseApertureShape* cpp_BaseApertureShape = (BaseApertureShape*) pyPrimitiveApertureShape->cpp_obj;	  	
   	std::string typeName = cpp_BaseApertureShape->getTypeName();
   	int settings_done = 0;
-  	std::cout << "debug PrimitiveApertureShape_setParams 1 "<<std::endl;
   	if(typeName == "circle"){
   		((CircleApertureShape*) cpp_BaseApertureShape)->setRadius(param1);
   		settings_done = 1;

--- a/src/orbit/Apertures/wrap_PrimitiveApertureShape.hh
+++ b/src/orbit/Apertures/wrap_PrimitiveApertureShape.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_PRIMITIVE_APERTURE_SHAPE_HH_
+#define WRAP_ORBIT_PRIMITIVE_APERTURE_SHAPE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_primitive_aperture_shape{
+    void initPrimitiveApertureShape(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_PRIMITIVE_APERTURE_SHAPE_HH_*/

--- a/src/orbit/Apertures/wrap_PyBaseApertureShape.cc
+++ b/src/orbit/Apertures/wrap_PyBaseApertureShape.cc
@@ -1,0 +1,182 @@
+#include "orbit_mpi.hh"
+#include "pyORBIT_Object.hh"
+
+#include "wrap_bunch.hh"
+
+#include <iostream>
+
+#include "PyBaseApertureShape.hh"
+
+namespace wrap_py_base_aperture_shape{
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	/** 
+	Constructor for python class wrapping c++ PyBaseApertureShape instance.
+      It never will be called directly.
+	*/
+	static PyObject* PyBaseApertureShape_new(PyTypeObject *type, PyObject *args, PyObject *kwds){
+		pyORBIT_Object* self;
+		self = (pyORBIT_Object *) type->tp_alloc(type, 0);
+		self->cpp_obj = NULL;
+		return (PyObject *) self;
+	}
+	
+  /** This is implementation of the __init__ method */
+  static int PyBaseApertureShape_init(pyORBIT_Object *self, PyObject *args, PyObject *kwds){
+	  self->cpp_obj =  new PyBaseApertureShape();
+	  ((PyBaseApertureShape*) self->cpp_obj)->setPyWrapper((PyObject*) self);
+    return 0;
+  }
+
+	// Sets or returns the center of the shape in X-direction 
+  static PyObject* PyBaseApertureShape_centerX(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPyBaseApertureShape= (pyORBIT_Object*) self;
+		PyBaseApertureShape* cpp_PyBaseApertureShape = (PyBaseApertureShape*) pyPyBaseApertureShape->cpp_obj;	
+		int nVars = PyTuple_Size(args);
+		if(nVars >= 1){
+			double center = 0.;
+			if(!PyArg_ParseTuple(	args,"d:centerX",&center)){
+				ORBIT_MPI_Finalize("PyBaseApertureShape.centerX(...) - call should be - centerX([center]). Stop.");
+			}
+			cpp_PyBaseApertureShape->setCenterX(center);
+    }
+		return Py_BuildValue("d",cpp_PyBaseApertureShape->getCenterX());
+  }
+  
+	// Sets or returns the center of the shape in Y-direction 
+  static PyObject* PyBaseApertureShape_centerY(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPyBaseApertureShape= (pyORBIT_Object*) self;
+		PyBaseApertureShape* cpp_PyBaseApertureShape = (PyBaseApertureShape*) pyPyBaseApertureShape->cpp_obj;	
+		int nVars = PyTuple_Size(args);
+		if(nVars >= 1){
+			double center = 0.;
+			if(!PyArg_ParseTuple(	args,"d:centerY",&center)){
+				ORBIT_MPI_Finalize("PyBaseApertureShape.centerY(...) - call should be - centerY([center]). Stop.");
+			}
+			cpp_PyBaseApertureShape->setCenterY(center);
+    }
+		return Py_BuildValue("d",cpp_PyBaseApertureShape->getCenterY());
+  }	  
+
+	// name([name]) - sets or returns the name of the shape 
+  static PyObject* PyBaseApertureShape_name(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPyBaseApertureShape= (pyORBIT_Object*) self;
+		PyBaseApertureShape* cpp_PyBaseApertureShape = (PyBaseApertureShape*) pyPyBaseApertureShape->cpp_obj;		
+    const char* name = NULL;
+    if(!PyArg_ParseTuple(	args,"|s:name",&name)){
+      ORBIT_MPI_Finalize("PyBaseApertureShape.name(...) - call should be - name([name]). Stop.");
+    }
+		if(name != NULL){
+      std::string name_str(name);
+      cpp_PyBaseApertureShape->setName(name_str);
+		}
+		return Py_BuildValue("s",cpp_PyBaseApertureShape->getName().c_str());
+  }
+  
+	// typeName() - returns the type name of the shape 
+  static PyObject* PyBaseApertureShape_typeName(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPyBaseApertureShape= (pyORBIT_Object*) self;
+		PyBaseApertureShape* cpp_PyBaseApertureShape = (PyBaseApertureShape*) pyPyBaseApertureShape->cpp_obj;
+		int nVars = PyTuple_Size(args);
+		if(nVars != 0){
+			ORBIT_MPI_Finalize("PyBaseApertureShape.typeName() - has no parameters. Stop.");
+    }
+		return Py_BuildValue("s",cpp_PyBaseApertureShape->getTypeName().c_str());
+  }  
+  
+	// Returns empty parameters dictionary - could be overloaded in Python subclass
+  static PyObject* PyBaseApertureShape_getParamsDict(PyObject *self, PyObject *args){
+    pyORBIT_Object* pyPyBaseApertureShape= (pyORBIT_Object*) self;
+		PyBaseApertureShape* cpp_PyBaseApertureShape = (PyBaseApertureShape*) pyPyBaseApertureShape->cpp_obj;	
+		PyObject* paramsDict = PyDict_New();
+		return paramsDict;
+  }  
+  
+  //-----------------------------------------------------
+  //destructor for python PyBaseApertureShape class (__del__ method).
+  //-----------------------------------------------------
+  static void PyBaseApertureShape_del(pyORBIT_Object* self){
+		//std::cerr<<"debug PyBaseApertureShape __del__ has been called!"<<std::endl;
+		delete ((PyBaseApertureShape*)self->cpp_obj);
+		self->ob_type->tp_free((PyObject*)self);
+  }
+	
+	// definition of the methods of the python PyBaseApertureShape wrapper class
+	// they will be vailable from python level
+	static PyMethodDef PyBaseApertureShapeClassMethods[] = {
+		{ "centerX",      PyBaseApertureShape_centerX,      METH_VARARGS,"Sets or returns the X-shift of the shape center."},	
+		{ "centerY",      PyBaseApertureShape_centerY,      METH_VARARGS,"Sets or returns the Y-shift of the shape center."},	
+		{ "name",         PyBaseApertureShape_name,         METH_VARARGS,"Sets or returns the name of the shape."},
+		{ "typeName",     PyBaseApertureShape_typeName,     METH_VARARGS,"Returns the type of the shape."},
+		{ "getParamsDict",PyBaseApertureShape_getParamsDict,METH_VARARGS,"Returns empty parameters dictionary."},			
+		{NULL}
+  };
+
+	static PyMemberDef PyBaseApertureShapeClassMembers [] = {
+		{NULL}
+	};
+	
+	
+	//new python PyBaseApertureShape wrapper type definition
+	static PyTypeObject pyORBIT_PyBaseApertureShape_Type = {
+		PyObject_HEAD_INIT(NULL)
+		0, /*ob_size*/
+		"PyBaseApertureShape", /*tp_name*/
+		sizeof(pyORBIT_Object), /*tp_basicsize*/
+		0, /*tp_itemsize*/
+		(destructor) PyBaseApertureShape_del , /*tp_dealloc*/
+		0, /*tp_print*/
+		0, /*tp_getattr*/
+		0, /*tp_setattr*/
+		0, /*tp_compare*/
+		0, /*tp_repr*/
+		0, /*tp_as_number*/
+		0, /*tp_as_sequence*/
+		0, /*tp_as_mapping*/
+		0, /*tp_hash */
+		0, /*tp_call*/
+		0, /*tp_str*/
+		0, /*tp_getattro*/
+		0, /*tp_setattro*/
+		0, /*tp_as_buffer*/
+		Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+		"The PyBaseApertureShape python wrapper", /* tp_doc */
+		0, /* tp_traverse */
+		0, /* tp_clear */
+		0, /* tp_richcompare */
+		0, /* tp_weaklistoffset */
+		0, /* tp_iter */
+		0, /* tp_iternext */
+		PyBaseApertureShapeClassMethods, /* tp_methods */
+		PyBaseApertureShapeClassMembers, /* tp_members */
+		0, /* tp_getset */
+		0, /* tp_base */
+		0, /* tp_dict */
+		0, /* tp_descr_get */
+		0, /* tp_descr_set */
+		0, /* tp_dictoffset */
+		(initproc) PyBaseApertureShape_init, /* tp_init */
+		0, /* tp_alloc */
+		PyBaseApertureShape_new, /* tp_new */
+	};	
+	
+	//--------------------------------------------------
+	//Initialization PyBaseApertureShape class
+	//--------------------------------------------------
+
+	void initPyBaseApertureShape(PyObject* module){
+		//check that the PyBaseApertureShape wrapper is ready
+		if (PyType_Ready(&pyORBIT_PyBaseApertureShape_Type) < 0) return;
+		Py_INCREF(&pyORBIT_PyBaseApertureShape_Type);
+		PyModule_AddObject(module, "PyBaseApertureShape", (PyObject *)&pyORBIT_PyBaseApertureShape_Type);			
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+}

--- a/src/orbit/Apertures/wrap_PyBaseApertureShape.hh
+++ b/src/orbit/Apertures/wrap_PyBaseApertureShape.hh
@@ -1,0 +1,18 @@
+#ifndef WRAP_ORBIT_PY_BASE_APERTURE_SHAPE_HH_
+#define WRAP_ORBIT_PY_BASE_APERTURE_SHAPE_HH_
+
+#include "Python.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  namespace wrap_py_base_aperture_shape{
+    void initPyBaseApertureShape(PyObject* module);
+  }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*WRAP_ORBIT_PY_BASE_APERTURE_SHAPE_HH_*/

--- a/src/orbit/Apertures/wrap_aperture.cc
+++ b/src/orbit/Apertures/wrap_aperture.cc
@@ -6,6 +6,11 @@
 #include "wrap_TAperture.hh"
 #include "wrap_PhaseAperture.hh"
 #include "wrap_EnergyAperture.hh"
+#include "wrap_BaseAperture.hh"
+#include "wrap_PyBaseApertureShape.hh"
+#include "wrap_PrimitiveApertureShape.hh"
+#include "wrap_CompositeApertureShape.hh"
+#include "wrap_ConvexApertureShape.hh"
 
 #include "wrap_bunch.hh"
 
@@ -29,6 +34,11 @@ extern "C" {
 		wrap_aperture::initTAperture(module);
 		wrap_phase_aperture::initPhaseAperture(module);
 		wrap_energy_aperture::initEnergyAperture(module);
+		wrap_base_aperture::initBaseAperture(module);
+		wrap_py_base_aperture_shape::initPyBaseApertureShape(module);
+		wrap_primitive_aperture_shape::initPrimitiveApertureShape(module);
+		wrap_py_composite_aperture_shape::initCompositeApertureShape(module);
+		wrap_convex_aperture_shape::initConvexApertureShape(module);
 	}
 
 #ifdef __cplusplus


### PR DESCRIPTION
The BaseAperture and BaseApertureShape classes were prepared to deal with arbitrary apertures. At this moment only Linac lattice is using the new apertures. TEAPOT lattice uses old style apertures.  