### PR TITLE
The bug in py/orbit/diagnostics/profiles.py fixed

### DIFF
--- a/src/spacecharge/Grid1D.hh
+++ b/src/spacecharge/Grid1D.hh
@@ -142,29 +142,16 @@ private:
   /** Memory allocation and step calculation for dx_ and dy_ */
   void init();
 
-  /** 
-     This is method for interpolation. The grid point responsibility is defined 
-     differently for binning and interpolation.  
-      Returns the grid indices and interpolation coefficients for a given z.
-      The indices bracket the point of interpolation:
-      0 <= ind <= nBins - 1
-      The coefficients Wz0 and Wzp correspond to ind and indp 
-    */
+	/** 
+			The grid is considered as periodic. The 1st bin is also the next to the last.
+			Returns the grid indices and binning/interpolating coefficients for a given z.
+			The indices bracket the point of interpolation:
+			0 <= iZ0, iZp <= nBins - 1
+			The coefficients WZ0 and WZp correspond to iZ0 and iZp 
+		*/
   void getIndAndWZ(double z,
                    int& ind0  , int& indp,
                    double& Wz0, double& Wzp);
-  
-   /** 
-      This is method for binning. The grid point responsibility is defined 
-      differently for binning and interpolation.   
-      Returns the grid indices and interpolation coefficients for a given z.
-      The indices bracket the point of interpolation:
-      0 <= ind <= nBins - 1
-      The coefficients Wz0 and Wzp correspond to ind and indp 
-    */
-  void getBinIndAndWZ(double z,
-                   int& ind0  , int& indp,
-                   double& Wz0, double& Wzp); 
 
   /** 
       This is method for interpolation. The grid point responsibility is defined 


### PR DESCRIPTION
The min(partdat) statement in py/orbit/diagnostics/profiles.py was ca using crash for zero particles case. The logic was too complicated also. The source of was modified by using Grid1D class as a standard procedure. The Grid1D was fixed for the linear interpolation coefficients to avoid negative values for start and end of the distribution.