### PR TITLE
The solenoid zero B=0 and Trajectory correction for Dipole Corr. bugs were fixed 

### DIFF
--- a/py/orbit/py_linac/orbit_correction/transport_lines_orbit_correction.py
+++ b/py/orbit/py_linac/orbit_correction/transport_lines_orbit_correction.py
@@ -191,14 +191,29 @@ class TrajectoryCorrection:
 		if(dc_node_arr == None): return
 		del dc_node_arr[:]
 		if(nodes == None):
-			dc_node_arr += self.lattice.getNodesOfClass(class_type)
+			nodes_tmp = self.lattice.getNodes()
+			if(len(nodes_tmp) == 0): return
+			(start_ind,stop_ind) = self._getStartStopIndexes()
+			if(start_ind < 0): start_ind = 0
+			if(stop_ind < 0): stop_ind = len(nodes_tmp)
+			nodes_tmp = nodes_tmp[start_ind:stop_ind]
+			for node in nodes_tmp:
+				if(isinstance(node,class_type)):
+					dc_node_arr.append(node)
+				else:
+					child_nodes = node.getAllChildren()
+					for child_node in child_nodes:
+						if(isinstance(child_node,class_type)):
+							dc_node_arr.append(child_node)						
 		else:
 			for node in nodes:
 				if(isinstance(node,class_type)):
 					dc_node_arr.append(node)
-		node_arr = self._returnFilteredNodes(dc_node_arr)
-		del dc_node_arr[:]
-		dc_node_arr += node_arr
+				else:
+					child_nodes = node.getAllChildren()
+					for child_node in child_nodes:
+						if(isinstance(child_node,class_type)):
+							dc_node_arr.append(child_node)
 		return dc_node_arr
 
 	def _updateQuad_Nodes(self, nodes = None):

--- a/src/teapot/teapotbase.cc
+++ b/src/teapot/teapotbase.cc
@@ -1351,6 +1351,12 @@ void bendfringeOUT(Bunch* bunch, double rho)
 
 void soln(Bunch* bunch, double length, double B, int useCharge)
 {
+    //if solenoid field in [T] is zero we have just a drift
+    if(abs(B) < 1.0e-100){
+    	drift(bunch,length);
+    	return;
+    }
+    
     double charge = +1.0;
     if(useCharge == 1) charge = bunch->getCharge();
     double Bc = B * charge;
@@ -1364,7 +1370,7 @@ void soln(Bunch* bunch, double length, double B, int useCharge)
     {
 	   syncPart->setTime( syncPart->getTime() + length/v);
     }
-
+    
     double gamma2i = 1.0 / (syncPart->getGamma() * syncPart->getGamma());
     double dp_p_coeff = 1.0 / (syncPart->getMomentum() * syncPart->getBeta());
     double dp_p;


### PR DESCRIPTION
If solenoid field is zero we have just a drift. This correction fixes the bug for B = 0. for solenoid bunch tracker. Before, I forgot to put drift(bunch,length) function. Thanks to Austin Hoover for noticing it.
Dipole correctors were missing in the case if they are children of Quad nodes. This situation is present for SNS SCL lattice. Fixed as response to the issue submitted by Fanglei Lin.