### PR TITLE
Update LinacTransportMatrixGenNodes.py - typo fixed

### DIFF
--- a/py/orbit/py_linac/lattice/LinacTransportMatrixGenNodes.py
+++ b/py/orbit/py_linac/lattice/LinacTransportMatrixGenNodes.py
@@ -166,7 +166,7 @@ class LinacTrMatrixGenNode(MarkerLinacNode):
 		m = self.trMtrx
 		for i in xrange(m.size()[0]):
 			for j in xrange(m.size()[1]):
-				print ("m(" + str(i) + "," + str(j)+")="+"%12.5g"%m.get(i,j) + " ", end = " ")
+				print ("m(" + str(i) + "," + str(j)+")="+"%12.5g"%m.get(i,j) + " "),
 			print " "		
 	
 

--- a/py/orbit/py_linac/lattice/LinacTransportMatrixGenNodes.py
+++ b/py/orbit/py_linac/lattice/LinacTransportMatrixGenNodes.py
@@ -229,13 +229,13 @@ class LinacTrMatricesContrioller:
 		self.init()
 		return self.trMatrxNodes
 			
-	def addTrMatrxGenNodesAtEntrance(self, accLattice, node_or_node):
+	def addTrMatrxGenNodesAtEntrance(self, accLattice, node_or_nodes):
 		"""
 		Adds the LinacTrMatrixGenNode to the nodes as child nodes at the entrance.
 		"""
 		self.addTrMatrxGenNodes(accLattice, node_or_nodes, MarkerLinacNode.ENTRANCE)
 		
-	def addTrMatrxGenNodesAtExit(self, accLattice, node_or_node):
+	def addTrMatrxGenNodesAtExit(self, accLattice, node_or_nodes):
 		"""
 		Adds the LinacTrMatrixGenNode to the nodes as child nodes at the exit.
 		"""		

--- a/py/orbit/py_linac/lattice/LinacTransportMatrixGenNodes.py
+++ b/py/orbit/py_linac/lattice/LinacTransportMatrixGenNodes.py
@@ -166,8 +166,8 @@ class LinacTrMatrixGenNode(MarkerLinacNode):
 		m = self.trMtrx
 		for i in xrange(m.size()[0]):
 			for j in xrange(m.size()[1]):
-				print ("m(" + str(i) + "," + str(j)+")="+"%12.5g"%m.get(i,j) + " "),
-			print ""		
+				print ("m(" + str(i) + "," + str(j)+")="+"%12.5g"%m.get(i,j) + " ", end = " ")
+			print " "		
 	
 
 class LinacTrMatricesContrioller:
@@ -233,11 +233,11 @@ class LinacTrMatricesContrioller:
 		"""
 		Adds the LinacTrMatrixGenNode to the nodes as child nodes at the entrance.
 		"""
-		self.addTrMatrxGenNodes(accLattice, node_or_nodes, MarkerLinacNode.ENTRANCE)
+		return self.addTrMatrxGenNodes(accLattice, node_or_nodes, MarkerLinacNode.ENTRANCE)
 		
 	def addTrMatrxGenNodesAtExit(self, accLattice, node_or_nodes):
 		"""
 		Adds the LinacTrMatrixGenNode to the nodes as child nodes at the exit.
 		"""		
-		self.addTrMatrxGenNodes(accLattice, node_or_nodes, MarkerLinacNode.EXIT)	
+		return self.addTrMatrxGenNodes(accLattice, node_or_nodes, MarkerLinacNode.EXIT)	
 			


### PR DESCRIPTION
The simple typo in parameter names of methods addTrMatrxGenNodesAtEntrance and addTrMatrxGenNodesAtExit in the LinacTrMatricesContrioller class.