### PR TITLE
Bunch Ring Wrapper nodes added to ENTRANCE and EXIT instead of BODY

### DIFF
--- a/py/orbit/teapot/teapot.py
+++ b/py/orbit/teapot/teapot.py
@@ -167,9 +167,6 @@ class TEAPOT_Ring(TEAPOT_Lattice):
 		for node in self.getNodes():
 			length = node.getLength()
 			if(length > 0.):
-				bunchwrapper = BunchWrapTEAPOT(node.getName()+":Bunch_Wrap:Entrance")
-				bunchwrapper.getParamsDict()["ring_length"] = self.getLength()
-				node.addChildNode(bunchwrapper, AccNode.ENTRANCE)
 				bunchwrapper = BunchWrapTEAPOT(node.getName()+":Bunch_Wrap:Exit")
 				bunchwrapper.getParamsDict()["ring_length"] = self.getLength()
 				node.addChildNode(bunchwrapper, AccNode.EXIT)				


### PR DESCRIPTION
Bunch Ring Wrapper nodes were added to ENTRANCE and EXIT of the parent nodes with non-zero length instead of BODY. Now users can change the numbers of parts in the parent node right after the TEAPOT_Ring lattice initialization. 