### PR TITLE
Changes were made to fix usage of k1(n) strength of magnet multipoles…

### DIFF
--- a/py/orbit/py_linac/lattice/LinacAccNodes.py
+++ b/py/orbit/py_linac/lattice/LinacAccNodes.py
@@ -301,9 +301,11 @@ class Quad(LinacMagnetNode):
 			usageIN = node.getUsage()	
 			if(not usageIN):
 				return
-			bunch = paramsDict["bunch"]	
+			bunch = paramsDict["bunch"]
+			charge = bunch.charge()
 			momentum = bunch.getSyncParticle().momentum()
-			kq = node.getParam("dB/dr")/(3.335640952*momentum)
+			#---- The charge sign will be accounted for inside tracking module functions.			
+			kq = node.getParam("dB/dr")/(3.335640952*momentum/abs(charge))
 			poleArr = node.getParam("poles")
 			klArr = node.getParam("kls")
 			skewArr = node.getParam("skews")
@@ -322,8 +324,10 @@ class Quad(LinacMagnetNode):
 			if(not usageOUT):
 				return
 			bunch = paramsDict["bunch"]
+			charge = bunch.charge()
 			momentum = bunch.getSyncParticle().momentum()
-			kq = node.getParam("dB/dr")/(3.335640952*momentum)	
+			#---- The charge sign will be accounted for inside tracking module functions
+			kq = node.getParam("dB/dr")/(3.335640952*momentum/abs(charge))	
 			poleArr = node.getParam("poles")
 			klArr = node.getParam("kls")
 			skewArr = node.getParam("skews")
@@ -400,9 +404,14 @@ class Quad(LinacMagnetNode):
 		The Quad Combined Function TEAPOT  class implementation
 		of the AccNode class track(probe) method.
 		"""
-		bunch = paramsDict["bunch"]		
+		bunch = paramsDict["bunch"]
+		charge = bunch.charge()
 		momentum = bunch.getSyncParticle().momentum()
-		kq = self.getParam("dB/dr")/(3.335640952*momentum)	
+		#---- The sign of dB/dr will be delivered to tracking module
+		#---- functions without charge sign transformation as kq.
+		#---- The charge sign will be accounted for inside tracking module
+		#---- functions.
+		kq = self.getParam("dB/dr")/(3.335640952*momentum/abs(charge))	
 		nParts = self.getnParts()
 		index = self.getActivePartIndex()
 		length = self.getLength(index)
@@ -646,8 +655,7 @@ class Bend(LinacMagnetNode):
 			TPB.bend2(bunch, length)
 			TPB.bend1(bunch, length, theta/2.0)
 		return
-                
-                
+
 class DCorrectorH(LinacMagnetNode):
 	"""
 	The Horizontal Dipole Corrector.
@@ -684,11 +692,11 @@ class DCorrectorH(LinacMagnetNode):
 		length = self.getParam("effLength")/nParts
 		field = self.getParam("B")
 		bunch = paramsDict["bunch"]
+		charge = bunch.charge()
 		syncPart = bunch.getSyncParticle()
 		momentum = syncPart.momentum()
 		# dp/p = Q*c*B*L/p p in GeV/c c = 2.99792*10^8/10^9
-		# Q is used inside kick-method
-		kick = field*length*0.299792/momentum
+		kick = -field*charge*length*0.299792/momentum
 		self.tracking_module.kick(bunch,kick,0.,0.)
 
 class DCorrectorV(LinacMagnetNode):
@@ -727,11 +735,11 @@ class DCorrectorV(LinacMagnetNode):
 		length = self.getParam("effLength")/nParts
 		field = self.getParam("B")
 		bunch = paramsDict["bunch"]
+		charge = bunch.charge()
 		syncPart = bunch.getSyncParticle()
 		momentum = syncPart.momentum()
 		# dp/p = Q*c*B*L/p p in GeV/c, c = 2.99792*10^8/10^9
-		# Q is used inside kick-method
-		kick = field*length*0.299792/momentum
+		kick = field*charge*length*0.299792/momentum
 		self.tracking_module.kick(bunch,0,kick,0.)
 
 class ThickKick(LinacMagnetNode):
@@ -785,7 +793,8 @@ class ThickKick(LinacMagnetNode):
 		"""
 		The Thick Kick  class implementation of the AccNode class track(probe) method.
 		"""
-		bunch = paramsDict["bunch"]		
+		bunch = paramsDict["bunch"]
+		charge = bunch.charge()
 		momentum = bunch.getSyncParticle().momentum()
 		Bx = self.getParam("Bx")
 		By = self.getParam("By")	
@@ -795,9 +804,8 @@ class ThickKick(LinacMagnetNode):
 		#print "debug name =",self.getName()," Bx=",Bx," By=",By,"  L=",self.getLength(index)," index=",index
 		#==========================================
 		# dp/p = Q*c*B*L/p p in GeV/c, c = 2.99792*10^8/10^9
-		# Q is used inside kick-method
-		kickY = Bx*length*0.299792/momentum
-		kickX = By*length*0.299792/momentum
+		kickY = +Bx*charge*length*0.299792/momentum
+		kickX = -By*charge*length*0.299792/momentum
 		self.tracking_module.drift(bunch, length/2.0)
 		self.tracking_module.kick(bunch,kickX,kickY,0.)
 		self.tracking_module.drift(bunch, length/2.0)

--- a/py/orbit/py_linac/lattice/LinacAccNodes.py
+++ b/py/orbit/py_linac/lattice/LinacAccNodes.py
@@ -297,7 +297,7 @@ class Quad(LinacMagnetNode):
 		self.setType("linacQuad")
 
 		def fringeIN(node,paramsDict):
-			# B*rho = 3.335640952*momentum [T*m] if momentum in GeV/c
+			# B*rho = 3.335640952*momentum/charge [T*m] if momentum in GeV/c
 			usageIN = node.getUsage()	
 			if(not usageIN):
 				return
@@ -305,7 +305,7 @@ class Quad(LinacMagnetNode):
 			charge = bunch.charge()
 			momentum = bunch.getSyncParticle().momentum()
 			#---- The charge sign will be accounted for inside tracking module functions.			
-			kq = node.getParam("dB/dr")/(3.335640952*momentum/abs(charge))
+			kq = node.getParam("dB/dr")/bunch.B_Rho()
 			poleArr = node.getParam("poles")
 			klArr = node.getParam("kls")
 			skewArr = node.getParam("skews")
@@ -320,6 +320,7 @@ class Quad(LinacMagnetNode):
 				TPB.multpfringeIN(bunch,pole,k,skew)
 
 		def fringeOUT(node,paramsDict):
+			# B*rho = 3.335640952*momentum/charge [T*m] if momentum in GeV/c
 			usageOUT = node.getUsage()
 			if(not usageOUT):
 				return
@@ -327,7 +328,7 @@ class Quad(LinacMagnetNode):
 			charge = bunch.charge()
 			momentum = bunch.getSyncParticle().momentum()
 			#---- The charge sign will be accounted for inside tracking module functions
-			kq = node.getParam("dB/dr")/(3.335640952*momentum/abs(charge))	
+			kq = node.getParam("dB/dr")/bunch.B_Rho()	
 			poleArr = node.getParam("poles")
 			klArr = node.getParam("kls")
 			skewArr = node.getParam("skews")
@@ -408,10 +409,10 @@ class Quad(LinacMagnetNode):
 		charge = bunch.charge()
 		momentum = bunch.getSyncParticle().momentum()
 		#---- The sign of dB/dr will be delivered to tracking module
-		#---- functions without charge sign transformation as kq.
+		#---- functions as kq.
 		#---- The charge sign will be accounted for inside tracking module
 		#---- functions.
-		kq = self.getParam("dB/dr")/(3.335640952*momentum/abs(charge))	
+		kq = self.getParam("dB/dr")/bunch.B_Rho()
 		nParts = self.getnParts()
 		index = self.getActivePartIndex()
 		length = self.getLength(index)

--- a/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
+++ b/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
@@ -283,7 +283,8 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		nParts = self.getnParts()
 		index = self.getActivePartIndex()
 		part_length = self.getLength(index)		
-		bunch = paramsDict["bunch"]		
+		bunch = paramsDict["bunch"]
+		charge = bunch.charge()
 		syncPart = bunch.getSyncParticle()	
 		eKin_in = syncPart.kinEnergy()
 		momentum = syncPart.momentum()
@@ -308,10 +309,10 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		Ep = self.getEzFiledInternal(zp,rfCavity,E0L,rf_ampl)			
 		#------- track through a quad
 		G = self.getTotalField((zm+z0)/2)
-		GP = 0.
-		if(self.useLongField == True): GP = self.getTotalFieldDerivative((zm+z0)/2)
+		dB_dz = 0.
+		if(self.useLongField == True): dB_dz = self.getTotalFieldDerivative((zm+z0)/2)
 		if(abs(G) != 0.):
-			kq = G/(3.335640952*momentum)
+			kq = G/(3.335640952*momentum/abs(charge))
 			#------- track through a quad
 			step = part_length/2
 			self.tracking_module.quad1(bunch,step/4.0, kq)
@@ -319,9 +320,8 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 			self.tracking_module.quad1(bunch,step/2.0, kq)
 			self.tracking_module.quad2(bunch,step/2.0)
 			self.tracking_module.quad1(bunch,step/4.0, kq)
-			if(abs(GP) != 0.):
-				kqP = GP/(3.335640952*momentum)
-				self.tracking_module.quad3(bunch,step, kqP)
+			if(abs(dB_dz) != 0.):
+				self.tracking_module.quad3(bunch,step,dB_dz)
 		else:
 			self.tracking_module.drift(bunch,part_length/2)
 		self.part_pos += part_length/2
@@ -340,19 +340,18 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		self.cppGapModel.trackBunch(bunch,part_length/2,Em,E0,Ep,frequency,phase+delta_phase+modePhase)
 		#------- track through a quad		
 		G = self.getTotalField((z0+zp)/2)
-		GP = 0.
-		if(self.useLongField == True): GP = self.getTotalFieldDerivative((z0+zp)/2)		
+		dB_dz = 0.
+		if(self.useLongField == True): dB_dz = self.getTotalFieldDerivative((z0+zp)/2)		
 		if(abs(G) != 0.):
-			kq = G/(3.335640952*momentum)
+			kq = G/(3.335640952*momentum/abs(charge))
 			step = part_length/2
 			self.tracking_module.quad1(bunch,step/4.0, kq)
 			self.tracking_module.quad2(bunch,step/2.0)
 			self.tracking_module.quad1(bunch,step/2.0, kq)
 			self.tracking_module.quad2(bunch,step/2.0)
 			self.tracking_module.quad1(bunch,step/4.0, kq)
-			if(abs(GP) != 0.):
-				kqP = GP/(3.335640952*momentum)
-				self.tracking_module.quad3(bunch,step, kqP)
+			if(abs(dB_dz) != 0.):
+				self.tracking_module.quad3(bunch,step,dB_dz)
 		else:
 			self.tracking_module.drift(bunch,part_length/2)
 		#---- advance the particle position
@@ -615,15 +614,16 @@ class OverlappingQuadsNode(BaseLinacNode):
 		length = self.getLength(index)
 		if(index == 0): self.z_value = - self.getLength()/2
 		bunch = paramsDict["bunch"]
+		charge = bunch.charge()
 		momentum = bunch.getSyncParticle().momentum()		
 		n_steps = int(length/self.z_step)+1
 		z_step = length/n_steps
 		for z_ind in range(n_steps):
 			z = self.z_value + z_step*(z_ind+0.5)
 			G = self.getTotalField(z)
-			GP = 0.
-			if(self.useLongField == True): GP = self.getTotalFieldDerivative(z)			
-			kq = G/(3.335640952*momentum)
+			dB_dz = 0.
+			if(self.useLongField == True): dB_dz = self.getTotalFieldDerivative(z)			
+			kq = G/(3.335640952*momentum/abs(charge))
 			if(abs(kq) == 0.):
 				self.tracking_module.drift(bunch,z_step)
 				continue
@@ -633,9 +633,8 @@ class OverlappingQuadsNode(BaseLinacNode):
 			self.tracking_module.quad1(bunch,z_step/2.0, kq)
 			self.tracking_module.quad2(bunch,z_step/2.0)
 			self.tracking_module.quad1(bunch,z_step/4.0, kq)
-			if(abs(GP) != 0.):
-				kqP = GP/(3.335640952*momentum)
-				self.tracking_module.quad3(bunch,z_step, kqP)			
+			if(abs(dB_dz) != 0.):
+				self.tracking_module.quad3(bunch,z_step, dB_dz)			
 		self.z_value += length
 		
 	def getTotalField(self,z_from_center):

--- a/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
+++ b/py/orbit/py_linac/lattice/LinacFieldOverlappingNodes.py
@@ -312,7 +312,7 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		dB_dz = 0.
 		if(self.useLongField == True): dB_dz = self.getTotalFieldDerivative((zm+z0)/2)
 		if(abs(G) != 0.):
-			kq = G/(3.335640952*momentum/abs(charge))
+			kq = G/bunch.B_Rho()
 			#------- track through a quad
 			step = part_length/2
 			self.tracking_module.quad1(bunch,step/4.0, kq)
@@ -343,7 +343,7 @@ class AxisField_and_Quad_RF_Gap(AbstractRF_Gap):
 		dB_dz = 0.
 		if(self.useLongField == True): dB_dz = self.getTotalFieldDerivative((z0+zp)/2)		
 		if(abs(G) != 0.):
-			kq = G/(3.335640952*momentum/abs(charge))
+			kq = G/bunch.B_Rho()
 			step = part_length/2
 			self.tracking_module.quad1(bunch,step/4.0, kq)
 			self.tracking_module.quad2(bunch,step/2.0)
@@ -623,7 +623,7 @@ class OverlappingQuadsNode(BaseLinacNode):
 			G = self.getTotalField(z)
 			dB_dz = 0.
 			if(self.useLongField == True): dB_dz = self.getTotalFieldDerivative(z)			
-			kq = G/(3.335640952*momentum/abs(charge))
+			kq = G/bunch.B_Rho()
 			if(abs(kq) == 0.):
 				self.tracking_module.drift(bunch,z_step)
 				continue

--- a/src/linac/tracking/linac_tracking.cc
+++ b/src/linac/tracking/linac_tracking.cc
@@ -125,10 +125,7 @@ namespace linac_tracking
 	
 	void linac_quad1(Bunch* bunch, double length, double kq, int useCharge)
 	{
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-
-    if(kq == 0. || charge == 0.)
+    if(kq == 0. || bunch->getCharge() == 0.)
     {
     	linac_drift(bunch,length);
     	return;
@@ -154,7 +151,7 @@ namespace linac_tracking
     }
     
  		// ==== B*rho = 3.335640952*momentum/charge [T*m] if momentum in GeV/c ===
- 		double dB_dr = kq*3.335640952*syncPart->getMomentum()/charge;
+ 		double dB_dr = kq*bunch->getB_Rho();
  		
  		double mass = syncPart->getMass();
 		double Ekin_s = syncPart->getEnergy();
@@ -184,7 +181,7 @@ namespace linac_tracking
 			Etotal = Ekin + mass;
 			p2 = Ekin*(Ekin+2.0*mass); 
 			p = sqrt(p2);
-    	kqc = dB_dr/(3.335640952*p/fabs(charge));
+    	kqc = dB_dr/(3.335640952*p/bunch->getCharge());
 			beta_z = p/Etotal;
 			
     	sqrt_kq  = sqrt(fabs(kqc));
@@ -281,7 +278,7 @@ namespace linac_tracking
 	
 	void linac_quad3(Bunch* bunch, double length, double dB_dz)
 	{
-    double charge = charge = bunch->getCharge();
+    double charge = bunch->getCharge();
 
     if(dB_dz == 0. || charge == 0.)
     {

--- a/src/linac/tracking/linac_tracking.hh
+++ b/src/linac/tracking/linac_tracking.hh
@@ -46,7 +46,7 @@ namespace linac_tracking
 	     This function performs the transverse kicks correction, so the length
 	     is just a parameter.
 	*/		
-	void linac_quad3(Bunch* bunch, double length, double kq, int useCharge);	
+	void linac_quad3(Bunch* bunch, double length, double dB_dz);	
 	
 	
 	/**

--- a/src/linac/tracking/wrap_linac_tracking.cc
+++ b/src/linac/tracking/wrap_linac_tracking.cc
@@ -75,15 +75,15 @@ extern "C"
 	{
 		PyObject* pyBunch;
 		double length;
-		double kq;
+		double dB_dz = 0.;
 		int useCharge = 1;
 		if(!PyArg_ParseTuple(	args, "Odd:linac_quad3",
-			&pyBunch, &length,&kq))
+			&pyBunch, &length,&dB_dz))
 		{
-			error("linac tracking - linac_quad3(pyBunch,length,kq) - cannot parse arguments!");
+			error("linac tracking - linac_quad3(pyBunch,length,dB_dz) - cannot parse arguments!");
 		}
 		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object *) pyBunch)->cpp_obj;
-		linac_tracking::linac_quad3(cpp_bunch, length, kq, useCharge);
+		linac_tracking::linac_quad3(cpp_bunch, length, dB_dz);
 		Py_INCREF(Py_None);
 		return Py_None;
 	} 	

--- a/src/orbit/Bunch.cc
+++ b/src/orbit/Bunch.cc
@@ -771,7 +771,20 @@ void Bunch::compress()
 double Bunch::getMass(){   return mass;}
 double Bunch::getCharge(){ return charge;}
 double Bunch::getClassicalRadius(){ return classicalRadius;}
-double  Bunch::getMacroSize(){ return macroSizeForAll;}
+double Bunch::getMacroSize(){ return macroSizeForAll;}
+
+/**
+  Return the B*Rho parameter of the particle 
+  B*Rho = momentum/charge - [T*m]
+  or B*Rho = 3.335640952*momentum[GeV/c]/charge[electron charges]
+*/
+double Bunch::getB_Rho(){
+	double B_Rho = 1.0e+36;
+	if(charge != 0. && syncPart != NULL){
+		B_Rho = 3.335640952*syncPart->getMomentum()/charge;
+	}
+	return B_Rho;
+}
 
 double Bunch::setMass(double val){
   mass = val;

--- a/src/orbit/Bunch.hh
+++ b/src/orbit/Bunch.hh
@@ -111,6 +111,13 @@ public:
   double getClassicalRadius();     // m
   double getCharge();              // sign and value in abs(e-charge) only
   double getMacroSize();
+  
+  /**
+   Return the B*Rho parameter of the particle 
+   B*Rho = momentum/charge - [T*m]
+   or B*Rho = 3.335640952*momentum[GeV/c]/charge[electron charges]
+  */
+  double getB_Rho();
 
   double setMass(double mass);                // GeV
   double setCharge(double chrg);              // sign and value in abs(e-charge) only

--- a/src/orbit/wrap_bunch.cc
+++ b/src/orbit/wrap_bunch.cc
@@ -504,6 +504,13 @@ namespace wrap_orbit_bunch{
 		double val = cpp_bunch->getClassicalRadius();
 		return Py_BuildValue("d",val);
   }
+  
+  //Returns B_Rho of the particle in [Tesla*meter]. Parameter is used in TEAPOT
+  static PyObject* Bunch_B_Rho(PyObject *self, PyObject *args){	
+		Bunch* cpp_bunch = (Bunch*) ((pyORBIT_Object *) self)->cpp_obj;
+		double val = cpp_bunch->getB_Rho();
+		return Py_BuildValue("d",val);
+  }  
 
   //Sets or returns charge of the macro-particle in e-charge
   //  the action is depended on the number of arguments
@@ -1189,6 +1196,7 @@ namespace wrap_orbit_bunch{
     { "ringwrap",                       Bunch_ringwrap                      ,METH_VARARGS,"Perform the ring wrap. Usage: ringwrap(ring_length)"},
     { "mass",                           Bunch_mass                          ,METH_VARARGS,"Set mass(value) or get mass() the mass of particle in MeV"},
     { "classicalRadius",                Bunch_classicalRadius               ,METH_VARARGS,"Returns a classical radius of particle in [m]"},
+    { "B_Rho",                          Bunch_B_Rho                         ,METH_VARARGS,"Returns B*Rho parameter of particle in [T*m]"},
     { "charge",                         Bunch_charge                        ,METH_VARARGS,"Set charge(value) or get charge() the charge of particle in e-charge"},
     { "macroSize",                      Bunch_macroSize                     ,METH_VARARGS,"Set macroSize(value) or get macroSize() the charge of particle in e-charge"},
     { "initBunchAttr",                  Bunch_initBunchAttr                 ,METH_VARARGS,"Reads and initilizes bunch attributes from a bunch file"},

--- a/src/teapot/teapotbase.cc
+++ b/src/teapot/teapotbase.cc
@@ -1367,7 +1367,7 @@ void bendfringeOUT(Bunch* bunch, double rho)
 void soln(Bunch* bunch, double length, double B, int useCharge)
 {
     //if solenoid field in [T] is zero we have just a drift
-    if(abs(B) < 1.0e-100 || bunch->getCharge() == 0){
+    if(abs(B) < 1.0e-100 || bunch->getCharge() == 0.){
     	drift(bunch,length);
     	return;
     }

--- a/src/teapot/teapotbase.cc
+++ b/src/teapot/teapotbase.cc
@@ -269,6 +269,7 @@ void kick(Bunch* bunch, double kx, double ky, double kE, int useCharge)
 //   i = particle index
 //   pole = multipole number
 //   kl = integrated strength of the kick [m^(-pole)]
+//        kl already has information about the charge of particle.
 //   skew = 0 - normal, 1 - skew
 //
 // RETURNS
@@ -278,16 +279,11 @@ void kick(Bunch* bunch, double kx, double ky, double kE, int useCharge)
 
 void multpi(Bunch* bunch, int i, int pole, double kl, int skew, int useCharge)
 {
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-    
-    if(charge == 0.){
+    if(bunch->getCharge() == 0.){
     	return;
     }
     
-    charge = fabs(charge)/charge;
-    
-    double klc = kl * charge;
+    double klc = kl;
     std::complex<double> z, zn;
     double kl1;
 
@@ -329,6 +325,7 @@ void multpi(Bunch* bunch, int i, int pole, double kl, int skew, int useCharge)
 //   pole = multipole number 
 //   pole = 0 for dipole, pole = 1 for quad, pole = 2 for sextupole, pole = 3 for octupole
 //   kl = integrated strength of the kick [m^(-pole)]
+//        kl already has information about the charge of particle.
 //   skew = 0 - normal, 1 - skew
 //
 // RETURNS
@@ -338,16 +335,11 @@ void multpi(Bunch* bunch, int i, int pole, double kl, int skew, int useCharge)
 
 void multp(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 {
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-    
-    if(charge == 0.){
+    if(bunch->getCharge() == 0.){
     	return;
-    }
+    } 
     
-    charge = fabs(charge)/charge;    
-    
-    double klc = kl * charge;
+    double klc = kl;
     std::complex<double> z, zn;
     double kl1;
 
@@ -392,6 +384,7 @@ void multp(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 //   bunch  = reference to the macro-particle bunch
 //   pole = multipole number
 //   kl = multipole strength
+//        kl already has information about the charge of particle.
 //   skew = multipole skew
 //
 // RETURNS
@@ -401,16 +394,11 @@ void multp(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 
 void multpfringeIN(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 {
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-        
-    if(charge == 0.){
+    if(bunch->getCharge() == 0.){
     	return;
-    }
+    }  
     
-    charge = fabs(charge)/charge;   
-    
-    double klc = kl * charge;
+    double klc = kl;
     std::complex<double> rootm1 = std::complex<double>(0.0, 1.0);
 
     SyncPart* syncPart = bunch->getSyncPart();
@@ -509,6 +497,7 @@ void multpfringeIN(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 //   bunch  = reference to the macro-particle bunch
 //   pole = multipole number
 //   kl = multipole strength
+//        kl already has information about the charge of particle.
 //   skew = multipole skew
 //
 // RETURNS
@@ -518,16 +507,11 @@ void multpfringeIN(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 
 void multpfringeOUT(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 {
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-    
-    if(charge == 0.){
+    if(bunch->getCharge() == 0.){
     	return;
-    }
+    }   
     
-    charge = fabs(charge)/charge;    
-    
-    double klc = kl * charge;
+    double klc = kl;
     std::complex<double> rootm1 = std::complex<double>(0.0, 1.0);
 
     SyncPart* syncPart = bunch->getSyncPart();
@@ -626,6 +610,7 @@ void multpfringeOUT(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 //   bunch  = reference to the macro-particle bunch
 //   length = length of transport
 //   kq = quadrupole field strength [m^(-2)]
+//        kq already has information about the charge of particle.
 //
 // RETURNS
 //   Nothing
@@ -634,16 +619,13 @@ void multpfringeOUT(Bunch* bunch, int pole, double kl, int skew, int useCharge)
 
 void quad1(Bunch* bunch, double length, double kq, int useCharge)
 {
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-
-    if(kq == 0. || charge == 0.)
+    if(kq == 0. || bunch->getCharge() == 0.)
     {
         drift(bunch,length);
         return;
     }
     
-    double kqc = kq * charge/fabs(charge);
+    double kqc = kq;
     
     double x_init, xp_init, y_init, yp_init;
     double sqrt_kq, kqlength;
@@ -792,6 +774,7 @@ void quad3(Bunch* bunch, double length, double kq, int useCharge)
 // PARAMETERS
 //   bunch =  reference to the macro-particle bunch
 //   kq  = strength of quad
+//         kq already has information about the charge of particle.
 //
 // RETURNS
 //   Nothing
@@ -800,16 +783,11 @@ void quad3(Bunch* bunch, double length, double kq, int useCharge)
 
 void quadfringeIN(Bunch* bunch, double kq, int useCharge)
 {
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-    
-    if(charge == 0.){
+    if(bunch->getCharge() == 0.){
     	return;
-    }
+    }   
     
-    charge = fabs(charge)/charge;    
-    
-    double kqc = kq * charge;
+    double kqc = kq;
     double KNL, x_init, xp_init, y_init, yp_init, detM;
 
     SyncPart* syncPart = bunch->getSyncPart();
@@ -866,6 +844,7 @@ void quadfringeIN(Bunch* bunch, double kq, int useCharge)
 // PARAMETERS
 //   bunch  = reference to the macro-particle bunch
 //   kq  = strength of quad
+//         kq already has information about the charge of particle.
 //
 // RETURNS
 //   Nothing
@@ -874,16 +853,11 @@ void quadfringeIN(Bunch* bunch, double kq, int useCharge)
 
 void quadfringeOUT(Bunch* bunch, double kq, int useCharge)
 {
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
-    
-    if(charge == 0.){
+    if(bunch->getCharge() == 0.){
     	return;
-    }
+    }    
     
-    charge = fabs(charge)/charge;    
-    
-    double kqc = kq * charge;
+    double kqc = kq;
     double KNL, x_init, xp_init, y_init, yp_init, detM;
 
     SyncPart* syncPart = bunch->getSyncPart();
@@ -1393,15 +1367,12 @@ void bendfringeOUT(Bunch* bunch, double rho)
 void soln(Bunch* bunch, double length, double B, int useCharge)
 {
     //if solenoid field in [T] is zero we have just a drift
-    if(abs(B) < 1.0e-100){
+    if(abs(B) < 1.0e-100 || bunch->getCharge() == 0){
     	drift(bunch,length);
     	return;
     }
-    
-    double charge = +1.0;
-    if(useCharge == 1) charge = bunch->getCharge();
 
-    double Bc = B * charge;
+    double Bc = B * bunch->getCharge();
     double KNL, phase, cs, sn;
     double cu, cpu, u_init, pu_init, u, pu, phifac;
 

--- a/src/teapot/wrap_teapotbase.cc
+++ b/src/teapot/wrap_teapotbase.cc
@@ -488,7 +488,7 @@ extern "C"
 			{"rotatexy",         wrap_rotatexy,       METH_VARARGS, "Rotates bunch around z axis "},
 			{"drift",            wrap_drift,          METH_VARARGS, "Tracking a bunch through a drift "},
 			{"drifti",           wrap_drifti,         METH_VARARGS, "Drifts one macroparticle in the bunch"},
-			{"wrapbunch",		 wrap_wrapbunch,		  METH_VARARGS, "Tracking a bunch through a wrapbunch routine"},
+			{"wrapbunch",        wrap_wrapbunch,      METH_VARARGS, "Tracking a bunch through a wrapbunch routine"},
 			{"multp",            wrap_multp,          METH_VARARGS, "Tracking a bunch through a multipole "},
 			{"multpfringeIN",    wrap_multpfringeIN,  METH_VARARGS, "Tracking a bunch through an IN edge of a multipole "},
 			{"multpfringeOUT",   wrap_multpfringeOUT, METH_VARARGS, "Tracking a bunch through an OUT edge of a multipole"},


### PR DESCRIPTION
Changes were made to fix usage of k1(n) strength of magnet multipoles in the TEAPOT and linac tracking functions and methods. k1 for quad is dB/dr/(p0/charge), but the implementation was correct only for protons and and H- ions. The fix allows to use TEAPOT tracking for all heavy ions.
[kq1_coeff_in TEAPOT_base_magnets_problem.pdf](https://github.com/PyORBIT-Collaboration/py-orbit/files/14500769/kq1_coeff_in.TEAPOT_base_magnets_problem.pdf)
[quad_soft_edge_long_filed_kick.pdf](https://github.com/PyORBIT-Collaboration/py-orbit/files/14500770/quad_soft_edge_long_filed_kick.pdf)
